### PR TITLE
✨ All-day events

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,13 @@ yahoo(event); // https://calendar.yahoo.com/?v=60&title=...
 | `start` 👍       | Start time                  | JS Date / ISO 8601 string / Unix Timestamp  |
 | `end` 🤙         | End time                    | JS Date / ISO 8601 string / Unix Timestamp  |
 | `duration` 🤙    | Event duration              | Array with value (Number) and unit (String) |
+| `allDay` 🤙      | All day event               | Boolean                                     |
 | `description` 👌 | Information about the event | String                                      |
 | `location` 👌    | Event location in words     | String                                      |
 | `busy` 👌        | Mark on calendar as busy?   | Boolean                                     |
 | `guests` 🤞      | Emails of other guests      | Array of emails (String)                    |
+
+The `duration` field is ignored if `allDay` is used.
 
 #### Support key
 

--- a/index.test.ts
+++ b/index.test.ts
@@ -7,7 +7,29 @@ test("generate a google link", () => {
     duration: [2, "hour"]
   });
   expect(link).toBe(
-    "https://calendar.google.com/calendar/render?action=TEMPLATE&text=Birthday%20party&details=&location=&trp=&dates=20191228T230000Z%2F20191229T010000Z"
+    "https://calendar.google.com/calendar/render?action=TEMPLATE&text=Birthday%20party&details=&location=&trp=&dates=20191229T000000Z%2F20191229T020000Z"
+  );
+});
+
+test("generate a google link with time & timezone", () => {
+  const link = google({
+    title: "Birthday party",
+    start: "2019-12-29T12:00:00.000+01:00",
+    duration: [2, "hour"]
+  });
+  expect(link).toBe(
+    "https://calendar.google.com/calendar/render?action=TEMPLATE&text=Birthday%20party&details=&location=&trp=&dates=20191229T110000Z%2F20191229T130000Z"
+  );
+});
+
+test("generate an all day google link", () => {
+  const link = google({
+    title: "Birthday party",
+    start: "2019-12-29",
+    allDay: true
+  });
+  expect(link).toBe(
+    "https://calendar.google.com/calendar/render?action=TEMPLATE&text=Birthday%20party&details=&location=&trp=&dates=20191229%2F20191230"
   );
 });
 
@@ -19,7 +41,7 @@ test("generate a google link with guests", () => {
     guests: ["hello@example.com", "another@example.com"]
   });
   expect(link).toBe(
-    "https://calendar.google.com/calendar/render?action=TEMPLATE&text=Birthday%20party&details=&location=&trp=&dates=20191228T230000Z%2F20191229T010000Z&add=hello%40example.com%2Canother%40example.com"
+    "https://calendar.google.com/calendar/render?action=TEMPLATE&text=Birthday%20party&details=&location=&trp=&dates=20191229T000000Z%2F20191229T020000Z&add=hello%40example.com%2Canother%40example.com"
   );
 });
 
@@ -30,7 +52,18 @@ test("generate a yahoo link", () => {
     duration: [2, "hour"]
   });
   expect(link).toBe(
-    "https://calendar.yahoo.com/?v=60&title=Birthday%20party&st=20191229T000000&et=20191229T020000&desc=&in_loc="
+    "https://calendar.yahoo.com/?v=60&title=Birthday%20party&st=20191229T000000Z&et=20191229T020000Z&desc=&in_loc="
+  );
+});
+
+test("generate an all day yahoo link", () => {
+  const link = yahoo({
+    title: "Birthday party",
+    start: "2019-12-29",
+    allDay: true
+  });
+  expect(link).toBe(
+    "https://calendar.yahoo.com/?v=60&title=Birthday%20party&st=20191229&et=20191230&desc=&in_loc="
   );
 });
 
@@ -42,5 +75,16 @@ test("generate a outlook link", () => {
   });
   expect(link).toBe(
     "https://outlook.live.com/owa/?path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=20191229T000000&enddt=20191229T020000&subject=Birthday%20party&body=&location="
+  );
+});
+
+test("generate an all day outlook link", () => {
+  const link = outlook({
+    title: "Birthday party",
+    start: "2019-12-29",
+    allDay: true
+  });
+  expect(link).toBe(
+    "https://outlook.live.com/owa/?path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=20191229&enddt=20191230&subject=Birthday%20party&body=&location="
   );
 });

--- a/index.test.ts
+++ b/index.test.ts
@@ -33,6 +33,18 @@ test("generate an all day google link", () => {
   );
 });
 
+test("generate a multi day google link", () => {
+  const link = google({
+    title: "Birthday party",
+    start: "2019-12-29",
+    end: "2020-01-12",
+    allDay: true
+  });
+  expect(link).toBe(
+    "https://calendar.google.com/calendar/render?action=TEMPLATE&text=Birthday%20party&details=&location=&trp=&dates=20191229%2F20200112"
+  );
+});
+
 test("generate a google link with guests", () => {
   const link = google({
     title: "Birthday party",

--- a/index.ts
+++ b/index.ts
@@ -7,17 +7,19 @@ dayjs.extend(utc);
 
 export const eventify = (event: CalendarEvent) => {
   event.start = dayjs(event.start).toDate();
-  if (event.duration && event.duration.length && !event.end) {
-    const duration = Number(event.duration[0]);
-    const unit = event.duration[1];
-    event.end = dayjs(event.start)
-      .add(duration, unit)
-      .toDate();
-  }
-  if (event.allDay) {
-    event.end = dayjs(event.start)
-      .add(1, "day")
-      .toDate();
+  if (event.end == null) {
+    if (event.duration && event.duration.length) {
+      const duration = Number(event.duration[0]);
+      const unit = event.duration[1];
+      event.end = dayjs(event.start)
+        .add(duration, unit)
+        .toDate();
+    }
+    if (event.allDay) {
+      event.end = dayjs(event.start)
+        .add(1, "day")
+        .toDate();
+    }
   }
   return event;
 };

--- a/interfaces.ts
+++ b/interfaces.ts
@@ -5,6 +5,7 @@ interface CalendarEvent {
   start: any;
   end?: any;
   duration?: [number, dayjs.UnitType];
+  allDay?: boolean;
   description?: string;
   location?: string;
   busy?: boolean;


### PR DESCRIPTION
Hi Anand, thanks for the great library, this has saved me loads of time.

For a project I'm working on I need the ability to create all-day events. According to [these docs](https://github.com/InteractionDesignFoundation/add-event-to-calendar-docs) this is possible by using `YYYYMMDD` format for the start/end times on all of the services. I have verified that this works on Google Calendar, but I don't use any of the other services, so I'm trusting the docs that this actually works on Yahoo/Outlook...

I have also changed the timezone behavior slightly: I explicitly convert all the passed-in dates to UTC, which in my opinion is the correct behavior. I got test failures on the current master (without making any changes) because I am on UK time - I assume you are on EU time, as the times were offset by an hour.

Hope this all makes sense, thanks a lot!