### PR TITLE
Allow url to be specified explicitly to avoid document dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,11 @@ ics(event); // standard ICS calendar base on https://icalendar.org/
 | `location` 👌    | Event location in words     | String                                      |
 | `busy` 👌        | Mark on calendar as busy?   | Boolean                                     |
 | `guests` 🤞      | Emails of other guests      | Array of emails (String)                    |
+| `url` 🤞         | Calendar document URL       | String                                      |
 
 The `duration` field is ignored if `allDay` is used.
+
+The `url` field defaults to `document.URL` if a document global exists.
 
 #### Support key
 

--- a/index.test.ts
+++ b/index.test.ts
@@ -4,18 +4,21 @@ import { google, yahoo, outlook, ics } from "./index";
 import { TimeFormats } from "./utils";
 import { CalendarEvent } from "./interfaces";
 
-describe('Calendar Links', () => {
-  describe('Google', () => {
+describe("Calendar Links", () => {
+  describe("Google", () => {
     test("generate a google link", () => {
       const event: CalendarEvent = {
         title: "Birthday party",
         start: "2019-12-29",
-        duration: [2, "hour"]
-      }
+        duration: [2, "hour"],
+      };
       const link = google(event);
-      const sTime = dayjs(event.start).utc().format(TimeFormats.dateTimeUTC)
-      const eTime = dayjs(event.start).add(2, 'hour').utc().format(TimeFormats.dateTimeUTC)
-      const expectedDates = encodeURIComponent(`${sTime}/${eTime}`)
+      const sTime = dayjs(event.start).utc().format(TimeFormats.dateTimeUTC);
+      const eTime = dayjs(event.start)
+        .add(2, "hour")
+        .utc()
+        .format(TimeFormats.dateTimeUTC);
+      const expectedDates = encodeURIComponent(`${sTime}/${eTime}`);
       expect(link).toBe(
         `https://calendar.google.com/calendar/render?action=TEMPLATE&dates=${expectedDates}&text=Birthday%20party`
       );
@@ -25,12 +28,15 @@ describe('Calendar Links', () => {
       const event: CalendarEvent = {
         title: "Birthday party",
         start: "2019-12-29T12:00:00.000+01:00",
-        duration: [2, "hour"]
-      }
+        duration: [2, "hour"],
+      };
       const link = google(event);
-      const sTime = dayjs(event.start).utc().format(TimeFormats.dateTimeUTC)
-      const eTime = dayjs(event.start).add(2, 'hour').utc().format(TimeFormats.dateTimeUTC)
-      const expectedDates = encodeURIComponent(`${sTime}/${eTime}`)
+      const sTime = dayjs(event.start).utc().format(TimeFormats.dateTimeUTC);
+      const eTime = dayjs(event.start)
+        .add(2, "hour")
+        .utc()
+        .format(TimeFormats.dateTimeUTC);
+      const expectedDates = encodeURIComponent(`${sTime}/${eTime}`);
       expect(link).toBe(
         `https://calendar.google.com/calendar/render?action=TEMPLATE&dates=${expectedDates}&text=Birthday%20party`
       );
@@ -40,12 +46,15 @@ describe('Calendar Links', () => {
       const event: CalendarEvent = {
         title: "Birthday party",
         start: "2019-12-29",
-        allDay: true
-      }
+        allDay: true,
+      };
       const link = google(event);
-      const sTime = dayjs(event.start).utc().format(TimeFormats.allDay)
-      const eTime = dayjs(event.start).add(1, 'day').utc().format(TimeFormats.allDay)
-      const expectedDates = encodeURIComponent(`${sTime}/${eTime}`)
+      const sTime = dayjs(event.start).utc().format(TimeFormats.allDay);
+      const eTime = dayjs(event.start)
+        .add(1, "day")
+        .utc()
+        .format(TimeFormats.allDay);
+      const expectedDates = encodeURIComponent(`${sTime}/${eTime}`);
       expect(link).toBe(
         `https://calendar.google.com/calendar/render?action=TEMPLATE&dates=${expectedDates}&text=Birthday%20party`
       );
@@ -56,12 +65,12 @@ describe('Calendar Links', () => {
         title: "Birthday party",
         start: "2019-12-29",
         end: "2020-01-12",
-        allDay: true
-      }
+        allDay: true,
+      };
       const link = google(event);
-      const sTime = dayjs(event.start).utc().format(TimeFormats.allDay)
-      const eTime = dayjs(event.end).utc().format(TimeFormats.allDay)
-      const expectedDates = encodeURIComponent(`${sTime}/${eTime}`)
+      const sTime = dayjs(event.start).utc().format(TimeFormats.allDay);
+      const eTime = dayjs(event.end).utc().format(TimeFormats.allDay);
+      const expectedDates = encodeURIComponent(`${sTime}/${eTime}`);
       expect(link).toBe(
         `https://calendar.google.com/calendar/render?action=TEMPLATE&dates=${expectedDates}&text=Birthday%20party`
       );
@@ -72,28 +81,38 @@ describe('Calendar Links', () => {
         title: "Birthday party",
         start: "2019-12-29",
         duration: [2, "hour"],
-        guests: ["hello@example.com", "another@example.com"]
-      }
+        guests: ["hello@example.com", "another@example.com"],
+      };
       const link = google(event);
-      const sTime = dayjs(event.start).utc().format(TimeFormats.dateTimeUTC)
-      const eTime = dayjs(event.start).add(2, 'hour').utc().format(TimeFormats.dateTimeUTC)
-      const expectedDates = encodeURIComponent(`${sTime}/${eTime}`)
-      const expectedGuests = encodeURIComponent(event.guests ? event.guests.join() : '')
+      const sTime = dayjs(event.start).utc().format(TimeFormats.dateTimeUTC);
+      const eTime = dayjs(event.start)
+        .add(2, "hour")
+        .utc()
+        .format(TimeFormats.dateTimeUTC);
+      const expectedDates = encodeURIComponent(`${sTime}/${eTime}`);
+      const expectedGuests = encodeURIComponent(
+        event.guests ? event.guests.join() : ""
+      );
       expect(link).toBe(
         `https://calendar.google.com/calendar/render?action=TEMPLATE&add=${expectedGuests}&dates=${expectedDates}&text=Birthday%20party`
       );
     });
   });
-  describe('Yahoo', () => {
+  describe("Yahoo", () => {
     test("generate a yahoo link", () => {
       const event: CalendarEvent = {
         title: "Birthday party",
         start: "2019-12-29",
-        duration: [2, "hour"]
-      }
+        duration: [2, "hour"],
+      };
       const link = yahoo(event);
-      const sTime: String = dayjs(event.start).utc().format(TimeFormats.dateTimeUTC)
-      const eTime: String = dayjs(event.start).add(2, 'hour').utc().format(TimeFormats.dateTimeUTC)
+      const sTime: String = dayjs(event.start)
+        .utc()
+        .format(TimeFormats.dateTimeUTC);
+      const eTime: String = dayjs(event.start)
+        .add(2, "hour")
+        .utc()
+        .format(TimeFormats.dateTimeUTC);
 
       expect(link).toBe(
         `https://calendar.yahoo.com/?et=${eTime}&st=${sTime}&title=Birthday%20party&v=60`
@@ -104,26 +123,34 @@ describe('Calendar Links', () => {
       const event: CalendarEvent = {
         title: "Birthday party",
         start: "2019-12-29",
-        allDay: true
-      }
+        allDay: true,
+      };
       const link = yahoo(event);
-      const sTime: String = dayjs(event.start).utc().format(TimeFormats.allDay)
-      const eTime: String = dayjs(event.start).add(1, 'day').utc().format(TimeFormats.allDay)
+      const sTime: String = dayjs(event.start).utc().format(TimeFormats.allDay);
+      const eTime: String = dayjs(event.start)
+        .add(1, "day")
+        .utc()
+        .format(TimeFormats.allDay);
 
       expect(link).toBe(
         `https://calendar.yahoo.com/?et=${eTime}&st=${sTime}&title=Birthday%20party&v=60`
       );
     });
   });
-  describe('Outlook', () => {
+  describe("Outlook", () => {
     test("generate a outlook link", () => {
       const event: CalendarEvent = {
         title: "Birthday party",
         start: "2019-12-29",
-        duration: [2, "hour"]
-      }
-      const sTime: String = dayjs(event.start).utc().format(TimeFormats.dateTime)
-      const eTime: String = dayjs(event.start).add(2, 'hour').utc().format(TimeFormats.dateTime)
+        duration: [2, "hour"],
+      };
+      const sTime: String = dayjs(event.start)
+        .utc()
+        .format(TimeFormats.dateTime);
+      const eTime: String = dayjs(event.start)
+        .add(2, "hour")
+        .utc()
+        .format(TimeFormats.dateTime);
       const link = outlook(event);
 
       expect(link).toBe(
@@ -135,70 +162,148 @@ describe('Calendar Links', () => {
       const event: CalendarEvent = {
         title: "Birthday party",
         start: "2019-12-29",
-        allDay: true
-      }
+        allDay: true,
+      };
       const link = outlook(event);
-      const sTime: String = dayjs(event.start).utc().format(TimeFormats.allDay)
-      const eTime: String = dayjs(event.start).add(1, 'day').utc().format(TimeFormats.allDay)
+      const sTime: String = dayjs(event.start).utc().format(TimeFormats.allDay);
+      const eTime: String = dayjs(event.start)
+        .add(1, "day")
+        .utc()
+        .format(TimeFormats.allDay);
 
       expect(link).toBe(
         `https://outlook.live.com/owa/?enddt=${eTime}&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=${sTime}&subject=Birthday%20party`
       );
     });
   });
-  
-  describe('ICS', () => {
-    test('should generate an all day ics link', () => {
+
+  describe("ICS", () => {
+    test("should generate an all day ics link", () => {
       const event: CalendarEvent = {
         title: "Birthday party",
         start: "2019-12-29",
-        allDay: true
-      }
-      const sTime: string = dayjs(event.start).utc().format(TimeFormats.allDay)
-      const eTime: string = dayjs(event.start).add(1, 'day').utc().format(TimeFormats.allDay)
+        allDay: true,
+      };
+      const sTime: string = dayjs(event.start).utc().format(TimeFormats.allDay);
+      const eTime: string = dayjs(event.start)
+        .add(1, "day")
+        .utc()
+        .format(TimeFormats.allDay);
 
-      const link = ics(event)
-      expect(link).toBe(`data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0AVERSION:2.0%0ABEGIN:VEVENT%0AURL:${encodeURIComponent(document.URL)}%0ADTSTART:${sTime}%0ADTEND:${eTime}%0ASUMMARY:Birthday%20party%0AEND:VEVENT%0AEND:VCALENDAR%0A`)
-    })
-    test('should generate an ics link', () => {
+      const link = ics(event);
+      expect(link).toBe(
+        `data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0AVERSION:2.0%0ABEGIN:VEVENT%0AURL:${encodeURIComponent(
+          document.URL
+        )}%0ADTSTART:${sTime}%0ADTEND:${eTime}%0ASUMMARY:Birthday%20party%0AEND:VEVENT%0AEND:VCALENDAR%0A`
+      );
+    });
+    test("should generate an ics link", () => {
       const event: CalendarEvent = {
         title: "Birthday party",
         start: "2019-12-29",
-        duration: [2, "day"]
-      }
-      const sTime: string = dayjs(event.start).utc().format(TimeFormats.dateTimeUTC)
-      const eTime: string = dayjs(event.start).add(2, 'day').utc().format(TimeFormats.dateTimeUTC)
+        duration: [2, "day"],
+      };
+      const sTime: string = dayjs(event.start)
+        .utc()
+        .format(TimeFormats.dateTimeUTC);
+      const eTime: string = dayjs(event.start)
+        .add(2, "day")
+        .utc()
+        .format(TimeFormats.dateTimeUTC);
 
-      const link = ics(event)
-      expect(link).toBe(`data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0AVERSION:2.0%0ABEGIN:VEVENT%0AURL:${encodeURIComponent(document.URL)}%0ADTSTART:${sTime}%0ADTEND:${eTime}%0ASUMMARY:Birthday%20party%0AEND:VEVENT%0AEND:VCALENDAR%0A`)
-    })
-    
-    test('should generate an ics link with end date', () => {
+      const link = ics(event);
+      expect(link).toBe(
+        `data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0AVERSION:2.0%0ABEGIN:VEVENT%0AURL:${encodeURIComponent(
+          document.URL
+        )}%0ADTSTART:${sTime}%0ADTEND:${eTime}%0ASUMMARY:Birthday%20party%0AEND:VEVENT%0AEND:VCALENDAR%0A`
+      );
+    });
+
+    test("should generate an ics link with end date", () => {
       const event: CalendarEvent = {
         title: "Birthday party",
         start: "2019-12-23",
-        end: "2019-12-29"
-      }
-      const sTime: string = dayjs(event.start).utc().format(TimeFormats.dateTimeUTC)
-      const eTime: string = dayjs(event.end).utc().format(TimeFormats.dateTimeUTC)
+        end: "2019-12-29",
+      };
+      const sTime: string = dayjs(event.start)
+        .utc()
+        .format(TimeFormats.dateTimeUTC);
+      const eTime: string = dayjs(event.end)
+        .utc()
+        .format(TimeFormats.dateTimeUTC);
 
-      const link = ics(event)
-      expect(link).toBe(`data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0AVERSION:2.0%0ABEGIN:VEVENT%0AURL:${encodeURIComponent(document.URL)}%0ADTSTART:${sTime}%0ADTEND:${eTime}%0ASUMMARY:Birthday%20party%0AEND:VEVENT%0AEND:VCALENDAR%0A`)
-    })
+      const link = ics(event);
+      expect(link).toBe(
+        `data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0AVERSION:2.0%0ABEGIN:VEVENT%0AURL:${encodeURIComponent(
+          document.URL
+        )}%0ADTSTART:${sTime}%0ADTEND:${eTime}%0ASUMMARY:Birthday%20party%0AEND:VEVENT%0AEND:VCALENDAR%0A`
+      );
+    });
 
-    test('should generate an ics link with escaped characters', () => {
+    test("should generate an ics link with escaped characters", () => {
       const event: CalendarEvent = {
         title: "!#$%&'()*+,/:;=?@[] — Birthday party",
         description: "!#$%&'()*+,/:;=?@[] — My birthday!",
         location: "!#$%&'()*+,/:;=?@[] — My birthday!",
         start: "2019-12-23",
-        end: "2019-12-29"
-      }
-      const sTime: string = dayjs(event.start).utc().format(TimeFormats.dateTimeUTC)
-      const eTime: string = dayjs(event.end).utc().format(TimeFormats.dateTimeUTC)
+        end: "2019-12-29",
+      };
+      const sTime: string = dayjs(event.start)
+        .utc()
+        .format(TimeFormats.dateTimeUTC);
+      const eTime: string = dayjs(event.end)
+        .utc()
+        .format(TimeFormats.dateTimeUTC);
 
-      const link = ics(event)
-      expect(link).toBe(`data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0AVERSION:2.0%0ABEGIN:VEVENT%0AURL:${encodeURIComponent(document.URL)}%0ADTSTART:${sTime}%0ADTEND:${eTime}%0ASUMMARY:!%23%24%25%26'()*%2B%2C%2F%3A%3B%3D%3F%40%5B%5D%20%E2%80%94%20Birthday%20party%0ADESCRIPTION:!%23%24%25%26'()*%2B%2C%2F%3A%3B%3D%3F%40%5B%5D%20%E2%80%94%20My%20birthday!%0ALOCATION:!%23%24%25%26'()*%2B%2C%2F%3A%3B%3D%3F%40%5B%5D%20%E2%80%94%20My%20birthday!%0AEND:VEVENT%0AEND:VCALENDAR%0A`)
-    })
-  })
-})
+      const link = ics(event);
+      expect(link).toBe(
+        `data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0AVERSION:2.0%0ABEGIN:VEVENT%0AURL:${encodeURIComponent(
+          document.URL
+        )}%0ADTSTART:${sTime}%0ADTEND:${eTime}%0ASUMMARY:!%23%24%25%26'()*%2B%2C%2F%3A%3B%3D%3F%40%5B%5D%20%E2%80%94%20Birthday%20party%0ADESCRIPTION:!%23%24%25%26'()*%2B%2C%2F%3A%3B%3D%3F%40%5B%5D%20%E2%80%94%20My%20birthday!%0ALOCATION:!%23%24%25%26'()*%2B%2C%2F%3A%3B%3D%3F%40%5B%5D%20%E2%80%94%20My%20birthday!%0AEND:VEVENT%0AEND:VCALENDAR%0A`
+      );
+    });
+
+    test("should generate an all day ics link with a custom URL", () => {
+      const url = "https://example.com/birthday";
+      const event: CalendarEvent = {
+        title: "Birthday party",
+        start: "2019-12-29",
+        allDay: true,
+        url,
+      };
+      const sTime: string = dayjs(event.start).utc().format(TimeFormats.allDay);
+      const eTime: string = dayjs(event.start)
+        .add(1, "day")
+        .utc()
+        .format(TimeFormats.allDay);
+
+      const link = ics(event);
+      expect(link).toBe(
+        `data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0AVERSION:2.0%0ABEGIN:VEVENT%0AURL:${encodeURIComponent(
+          url
+        )}%0ADTSTART:${sTime}%0ADTEND:${eTime}%0ASUMMARY:Birthday%20party%0AEND:VEVENT%0AEND:VCALENDAR%0A`
+      );
+    });
+
+    test("allDay should take precedence over duration", () => {
+      const event: CalendarEvent = {
+        title: "Birthday party",
+        start: "2019-12-29",
+        allDay: true,
+        duration: [2, "day"],
+      };
+      const sTime: string = dayjs(event.start).utc().format(TimeFormats.allDay);
+      const eTime: string = dayjs(event.start)
+        .add(1, "day")
+        .utc()
+        .format(TimeFormats.allDay);
+
+      const link = ics(event);
+      expect(link).toBe(
+        `data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0AVERSION:2.0%0ABEGIN:VEVENT%0AURL:${encodeURIComponent(
+          document.URL
+        )}%0ADTSTART:${sTime}%0ADTEND:${eTime}%0ASUMMARY:Birthday%20party%0AEND:VEVENT%0AEND:VCALENDAR%0A`
+      );
+    });
+  });
+});

--- a/index.ts
+++ b/index.ts
@@ -2,46 +2,61 @@ import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import { stringify } from "query-string";
 
-import { CalendarEvent, Google, Outlook, Yahoo } from "./interfaces";
-import { TimeFormats } from './utils'
+import {
+  CalendarEvent,
+  NormalizedCalendarEvent,
+  Google,
+  Outlook,
+  Yahoo,
+} from "./interfaces";
+import { TimeFormats } from "./utils";
 
 dayjs.extend(utc);
 
-export const eventify = (event: CalendarEvent) => {
-  event.start = dayjs(event.start).toDate();
-  if (event.end == null) {
-    if (event.duration && event.duration.length) {
-      const duration = Number(event.duration[0]);
-      const unit = event.duration[1];
-      event.end = dayjs(event.start)
-        .add(duration, unit)
-        .toDate();
-    }
-    if (event.allDay) {
-      event.end = dayjs(event.start)
-        .add(1, "day")
-        .toDate();
-    }
+function formatTimes(
+  { allDay, startUtc, endUtc }: NormalizedCalendarEvent,
+  dateTimeFormat: Exclude<keyof typeof TimeFormats, "allDay">
+): { start: string; end: string } {
+  const format = TimeFormats[allDay ? "allDay" : dateTimeFormat];
+  return { start: startUtc.format(format), end: endUtc.format(format) };
+}
+
+export const eventify = (event: CalendarEvent): NormalizedCalendarEvent => {
+  const { start, end, duration, ...rest } = event;
+  const startUtc = dayjs(start).utc();
+  const endUtc = end
+    ? dayjs(end).utc()
+    : (() => {
+        if (event.allDay) {
+          return startUtc.add(1, "day");
+        }
+        if (duration && duration.length == 2) {
+          const value = Number(duration[0]);
+          const unit = duration[1];
+          return startUtc.add(value, unit);
+        }
+        return dayjs().utc();
+      })();
+  if (!rest.url && typeof document == "object") {
+    rest.url = document.URL;
   }
-  return event;
+  return {
+    ...rest,
+    startUtc,
+    endUtc,
+  };
 };
 
-export const google = (event: CalendarEvent) => {
-  event = eventify(event);
-  const format = event.allDay ? TimeFormats.allDay : TimeFormats.dateTimeUTC;
-  const start: string = dayjs(event.start)
-    .utc()
-    .format(format);
-  const end: string = dayjs(event.end)
-    .utc()
-    .format(format);
+export const google = (calendarEvent: CalendarEvent): string => {
+  const event = eventify(calendarEvent);
+  const { start, end } = formatTimes(event, "dateTimeUTC");
   const details: Google = {
     action: "TEMPLATE",
     text: event.title,
     details: event.description,
     location: event.location,
     trp: event.busy,
-    dates: start + "/" + end
+    dates: start + "/" + end,
   };
   if (event.guests && event.guests.length) {
     details.add = event.guests.join();
@@ -49,15 +64,9 @@ export const google = (event: CalendarEvent) => {
   return `https://calendar.google.com/calendar/render?${stringify(details)}`;
 };
 
-export const outlook = (event: CalendarEvent) => {
-  event = eventify(event);
-  const format = event.allDay ? TimeFormats.allDay : TimeFormats.dateTime;
-  const start: string = dayjs(event.start)
-    .utc()
-    .format(format);
-  const end: string = dayjs(event.end)
-    .utc()
-    .format(format);
+export const outlook = (calendarEvent: CalendarEvent): string => {
+  const event = eventify(calendarEvent);
+  const { start, end } = formatTimes(event, "dateTime");
   const details: Outlook = {
     path: "/calendar/action/compose",
     rru: "addevent",
@@ -65,98 +74,88 @@ export const outlook = (event: CalendarEvent) => {
     enddt: end,
     subject: event.title,
     body: event.description,
-    location: event.location
+    location: event.location,
   };
   return `https://outlook.live.com/owa/?${stringify(details)}`;
 };
 
-export const yahoo = (event: CalendarEvent) => {
-  event = eventify(event);
-  const format = event.allDay ? TimeFormats.allDay : TimeFormats.dateTimeUTC;
-  const start: string = dayjs(event.start)
-    .utc()
-    .format(format);
-  const end: string = dayjs(event.end)
-    .utc()
-    .format(format);
+export const yahoo = (calendarEvent: CalendarEvent): string => {
+  const event = eventify(calendarEvent);
+  const { start, end } = formatTimes(event, "dateTimeUTC");
   const details: Yahoo = {
     v: 60,
     title: event.title,
     st: start,
     et: end,
     desc: event.description,
-    in_loc: event.location
+    in_loc: event.location,
   };
   return `https://calendar.yahoo.com/?${stringify(details)}`;
 };
 
-export const ics = (event: CalendarEvent) => {
-  event = eventify(event);
+export const ics = (calendarEvent: CalendarEvent): string => {
+  const event = eventify(calendarEvent);
   const formattedDescription: string = (event.description || "")
     .replace(/\n/gm, "\\n")
     .replace(/(\\n)[\s\t]+/gm, "\\n");
 
-  const format = event.allDay ? TimeFormats.allDay : TimeFormats.dateTimeUTC;
-  const start: string = dayjs(event.start)
-    .utc()
-    .format(format);
-  const end: string = dayjs(event.end)
-    .utc()
-    .format(format);
+  const { start, end } = formatTimes(event, "dateTimeUTC");
   const calendarChunks = [
     {
-      key: 'BEGIN',
-      value: 'VCALENDAR'
+      key: "BEGIN",
+      value: "VCALENDAR",
     },
     {
-      key: 'VERSION',
-      value: '2.0'
+      key: "VERSION",
+      value: "2.0",
     },
     {
-      key: 'BEGIN',
-      value: 'VEVENT'
+      key: "BEGIN",
+      value: "VEVENT",
     },
     {
-      key: 'URL',
-      value: document.URL
+      key: "URL",
+      value: event.url,
     },
     {
-      key: 'DTSTART',
-      value: start
+      key: "DTSTART",
+      value: start,
     },
     {
-      key: 'DTEND',
-      value: end
+      key: "DTEND",
+      value: end,
     },
     {
-      key: 'SUMMARY',
-      value: event.title
+      key: "SUMMARY",
+      value: event.title,
     },
     {
-      key: 'DESCRIPTION',
-      value: formattedDescription
+      key: "DESCRIPTION",
+      value: formattedDescription,
     },
     {
-      key: 'LOCATION',
-      value: event.location
+      key: "LOCATION",
+      value: event.location,
     },
     {
-      key: 'END',
-      value: 'VEVENT'
+      key: "END",
+      value: "VEVENT",
     },
     {
-      key: 'END',
-      value: 'VCALENDAR'
+      key: "END",
+      value: "VCALENDAR",
     },
   ];
 
-  let calendarUrl: string = '';
+  let calendarUrl: string = "";
 
-  calendarChunks.forEach(chunk => {
-    if(chunk.value) {
+  calendarChunks.forEach((chunk) => {
+    if (chunk.value) {
       calendarUrl += `${chunk.key}:${encodeURIComponent(`${chunk.value}\n`)}`;
     }
   });
 
   return `data:text/calendar;charset=utf8,${calendarUrl}`;
 };
+
+export { CalendarEvent };

--- a/interfaces.ts
+++ b/interfaces.ts
@@ -10,6 +10,13 @@ interface CalendarEvent {
   location?: string;
   busy?: boolean;
   guests?: string[];
+  url?: string;
+}
+
+interface NormalizedCalendarEvent
+  extends Omit<CalendarEvent, "start" | "end" | "duration"> {
+  startUtc: dayjs.Dayjs;
+  endUtc: dayjs.Dayjs;
 }
 
 interface Google {
@@ -45,4 +52,4 @@ interface Yahoo {
   in_loc?: string;
 }
 
-export { CalendarEvent, Outlook, Yahoo, Google };
+export { CalendarEvent, NormalizedCalendarEvent, Outlook, Yahoo, Google };

--- a/utils.ts
+++ b/utils.ts
@@ -1,5 +1,5 @@
 export const TimeFormats = {
   dateTime: "YYYYMMDD[T]HHmmss",
   dateTimeUTC: "YYYYMMDD[T]HHmmss[Z]",
-  allDay: "YYYYMMDD"
+  allDay: "YYYYMMDD",
 };


### PR DESCRIPTION
This allows calendar-link to be used during server-side rendering,
such as with next.js

This PR also:

* exports the CalendarEvent interface
* makes the behavior of eventify treat event as immutable
* uses more explicit types for eventify
* ran prettier over the source