### PR TITLE
[bugfix] Add offset to Outlook and Office365 times

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -119,36 +119,26 @@ describe("Calendar Links", () => {
     test("generate a outlook link", () => {
       const event: CalendarEvent = {
         title: "Birthday party",
-        start: "2019-12-29",
+        start: "2019-12-29Z",
         duration: [2, "hour"],
       };
-      const sTime: String = dayjs(event.start).utc().format(TimeFormats.dateTime);
-      const eTime: String = dayjs(event.start).add(2, "hour").utc().format(TimeFormats.dateTime);
       const link = outlook(event);
 
       expect(link).toBe(
-        `https://outlook.live.com/calendar/0/deeplink/compose?enddt=${eTime}&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=${sTime}&subject=Birthday%20party`.replace(
-          /(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})/g,
-          "$1-$2-$3T$4:$5:$6"
-        )
+        "https://outlook.live.com/calendar/0/deeplink/compose?enddt=2019-12-29T02%3A00%3A00%2B00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00%2B00%3A00&subject=Birthday%20party"
       );
     });
 
     test("generate an all day outlook link", () => {
       const event: CalendarEvent = {
         title: "Birthday party",
-        start: "2019-12-29",
+        start: "2019-12-29Z",
         allDay: true,
       };
       const link = outlook(event);
-      const sTime: String = dayjs(event.start).utc().format(TimeFormats.allDay);
-      const eTime: String = dayjs(event.start).add(1, "day").utc().format(TimeFormats.allDay);
 
       expect(link).toBe(
-        `https://outlook.live.com/calendar/0/deeplink/compose?enddt=${eTime}&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=${sTime}&subject=Birthday%20party`.replace(
-          /(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})/g,
-          "$1-$2-$3T$4:$5:$6"
-        )
+        "https://outlook.live.com/calendar/0/deeplink/compose?enddt=20191230&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=20191229&subject=Birthday%20party"
       );
     });
   });
@@ -157,36 +147,26 @@ describe("Calendar Links", () => {
     test("generate a office365 link", () => {
       const event: CalendarEvent = {
         title: "Birthday party",
-        start: "2019-12-29",
+        start: "2019-12-29Z",
         duration: [2, "hour"],
       };
-      const sTime: String = dayjs(event.start).utc().format(TimeFormats.dateTime);
-      const eTime: String = dayjs(event.start).add(2, "hour").utc().format(TimeFormats.dateTime);
       const link = office365(event);
 
       expect(link).toBe(
-        `https://outlook.office.com/calendar/0/deeplink/compose?enddt=${eTime}&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=${sTime}&subject=Birthday%20party`.replace(
-          /(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})/g,
-          "$1-$2-$3T$4:$5:$6"
-        )
+        "https://outlook.office.com/calendar/0/deeplink/compose?enddt=2019-12-29T02%3A00%3A00%2B00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00%2B00%3A00&subject=Birthday%20party"
       );
     });
 
     test("generate an all day office365 link", () => {
       const event: CalendarEvent = {
         title: "Birthday party",
-        start: "2019-12-29",
+        start: "2019-12-29Z",
         allDay: true,
       };
       const link = office365(event);
-      const sTime: String = dayjs(event.start).utc().format(TimeFormats.allDay);
-      const eTime: String = dayjs(event.start).add(1, "day").utc().format(TimeFormats.allDay);
 
       expect(link).toBe(
-        `https://outlook.office.com/calendar/0/deeplink/compose?enddt=${eTime}&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=${sTime}&subject=Birthday%20party`.replace(
-          /(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})/g,
-          "$1-$2-$3T$4:$5:$6"
-        )
+        "https://outlook.office.com/calendar/0/deeplink/compose?enddt=20191230&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=20191229&subject=Birthday%20party"
       );
     });
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ export const google = (calendarEvent: CalendarEvent): string => {
 
 export const outlook = (calendarEvent: CalendarEvent): string => {
   const event = eventify(calendarEvent);
-  const { start, end } = formatTimes(event, "dateTime");
+  const { start, end } = formatTimes(event, "dateTimeWithOffset");
   const details: Outlook = {
     path: "/calendar/action/compose",
     rru: "addevent",
@@ -67,15 +67,12 @@ export const outlook = (calendarEvent: CalendarEvent): string => {
     body: event.description,
     location: event.location,
   };
-  return `https://outlook.live.com/calendar/0/deeplink/compose?${stringify(details)}`.replace(
-    /(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})/g,
-    "$1-$2-$3T$4:$5:$6"
-  );
+  return `https://outlook.live.com/calendar/0/deeplink/compose?${stringify(details)}`;
 };
 
 export const office365 = (calendarEvent: CalendarEvent): string => {
   const event = eventify(calendarEvent);
-  const { start, end } = formatTimes(event, "dateTime");
+  const { start, end } = formatTimes(event, "dateTimeWithOffset");
   const details: Outlook = {
     path: "/calendar/action/compose",
     rru: "addevent",
@@ -85,10 +82,7 @@ export const office365 = (calendarEvent: CalendarEvent): string => {
     body: event.description,
     location: event.location,
   };
-  return `https://outlook.office.com/calendar/0/deeplink/compose?${stringify(details)}`.replace(
-    /(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})/g,
-    "$1-$2-$3T$4:$5:$6"
-  );
+  return `https://outlook.office.com/calendar/0/deeplink/compose?${stringify(details)}`;
 };
 
 export const yahoo = (calendarEvent: CalendarEvent): string => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 export const TimeFormats = {
-  dateTime: "YYYYMMDD[T]HHmmss",
+  dateTimeWithOffset: "YYYY-MM-DD[T]HH:mm:ssZ",
   dateTimeUTC: "YYYYMMDD[T]HHmmss[Z]",
   allDay: "YYYYMMDD",
 };


### PR DESCRIPTION
Supplying a time without offset makes Outlook and Office365 assume the time is in the user's local time. But in reality the times in this case are actually converted to UTC times, hence the links created by the library are off.

I also removed the `.replace(...)` parts as we can just format the dates how we want to using day.js.

I also updated the tests for these cases so we don't use date mangling in them, because if we do the things that I changed aren't actually really tested. Let me know what you think of this.

This should fix https://github.com/AnandChowdhary/calendar-link/issues/236