### PR TITLE
Fix TypeScript imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
-  "exports": "dist/index.modern.js",
+  "exports": "./dist/index.modern.js",
   "umd:main": "dist/index.umd.js",
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
-  "exports": "./dist/index.modern.js",
+  "exports": {
+    "import": "./dist/index.modern.js",
+    "require": "./dist/index.js"
+  },
   "umd:main": "dist/index.umd.js",
   "files": [
     "dist"


### PR DESCRIPTION
Provide a fix for #337 and #338 by

a) using relative path in `exports` field of `package.json`
b) separating ESM and CSJ exports