### PR TITLE
Add event organizer and test

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -267,5 +267,24 @@ describe("Calendar Links", () => {
         `data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0AVERSION:2.0%0ABEGIN:VEVENT%0ADTSTART:${sTime}%0ADTEND:${eTime}%0ASUMMARY:Birthday%20party%0AEND:VEVENT%0AEND:VCALENDAR%0A`
       );
     });
+
+    test("should generate an ics link with a organizer", () => {
+      const event: CalendarEvent = {
+        title: "Birthday party",
+        start: "2019-12-29",
+        duration: [2, "day"],
+        organizer: {
+          name: 'John Doe',
+          email: 'john.doe@example.com'
+        }
+      };
+      const sTime: string = dayjs(event.start).utc().format(TimeFormats.dateTimeUTC);
+      const eTime: string = dayjs(event.start).add(2, "day").utc().format(TimeFormats.dateTimeUTC);
+
+      const link = ics(event);
+      expect(link).toBe(
+          `data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0AVERSION:2.0%0ABEGIN:VEVENT%0ADTSTART:20191229T050000Z%0ADTEND:20191231T050000Z%0ASUMMARY:Birthday%20party%0AORGANIZER;CN%3DJohn%20Doe%3AMAILTO%3Ajohn.doe%40example.com%0AEND:VEVENT%0AEND:VCALENDAR%0A`
+      );
+    });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import { stringify } from "query-string";
 
-import { CalendarEvent, NormalizedCalendarEvent, Google, Outlook, Yahoo } from "./interfaces";
+import { CalendarEvent, CalendarEventOrganizer, NormalizedCalendarEvent, Google, Outlook, Yahoo } from "./interfaces";
 import { TimeFormats } from "./utils";
 
 dayjs.extend(utc);
@@ -154,6 +154,10 @@ export const ics = (calendarEvent: CalendarEvent): string => {
       value: formattedLocation,
     },
     {
+      key: "ORGANIZER",
+      value: event.organizer,
+    },
+    {
       key: "END",
       value: "VEVENT",
     },
@@ -167,7 +171,12 @@ export const ics = (calendarEvent: CalendarEvent): string => {
 
   calendarChunks.forEach((chunk) => {
     if (chunk.value) {
-      calendarUrl += `${chunk.key}:${encodeURIComponent(`${chunk.value}\n`)}`;
+      if (chunk.key == "ORGANIZER") {
+        const value = chunk.value as CalendarEventOrganizer;
+        calendarUrl += `${chunk.key};${encodeURIComponent(`CN=${value.name}:MAILTO:${value.email}\n`)}`;
+      } else {
+        calendarUrl += `${chunk.key}:${encodeURIComponent(`${chunk.value}\n`)}`;
+      }
     }
   });
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -8,9 +8,15 @@ interface CalendarEvent {
   allDay?: boolean;
   description?: string;
   location?: string;
+  organizer?: CalendarEventOrganizer;
   busy?: boolean;
   guests?: string[];
   url?: string;
+}
+
+interface CalendarEventOrganizer {
+  name: string;
+  email: string;
 }
 
 interface NormalizedCalendarEvent extends Omit<CalendarEvent, "start" | "end" | "duration"> {
@@ -51,4 +57,4 @@ interface Yahoo extends Record<string, string | boolean | number | undefined> {
   in_loc?: string;
 }
 
-export { CalendarEvent, NormalizedCalendarEvent, Outlook, Yahoo, Google };
+export { CalendarEvent, CalendarEventOrganizer, NormalizedCalendarEvent, Outlook, Yahoo, Google };


### PR DESCRIPTION
This PR adds an Event Organizer key to the event configuration. This is an optional Key that, if provided, will add an ORGANIZER config to ICS files. These files, when emailed in gmail will then show the correct information rather than `Unknown Organizer` 

The organizer key is an interface with name and email, because the format of the field would be ambiguous without it. This can be simplified if needed, but is more clear as is.

Closes #404