### PR TITLE
Handle allday for Yahoo

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -97,6 +97,7 @@ export const yahoo = (calendarEvent: CalendarEvent): string => {
     et: end,
     desc: event.description,
     in_loc: event.location,
+    dur: event.allDay ? "allday" : false
   };
   return `https://calendar.yahoo.com/?${stringify(details)}`;
 };


### PR DESCRIPTION
Yahoo calendar expects a duration parameter set to `allday` for All day events.