### PR TITLE
Support local time (not UTC) for Outlook and Office365

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -135,26 +135,30 @@ describe("Calendar Links", () => {
     test("generate a outlook link", () => {
       const event: CalendarEvent = {
         title: "Birthday party",
-        start: "2019-12-29Z",
+        start: "2019-12-29",
         duration: [2, "hour"],
       };
+      const expectedOffsetString = dayjs(new Date()).format("Z");
+      const expectedOffsetStringEncoded = encodeURIComponent(expectedOffsetString);
       const link = outlook(event);
 
       expect(link).toBe(
-        "https://outlook.live.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T02%3A00%3A00%2B00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00%2B00%3A00&subject=Birthday%20party"
+        `https://outlook.live.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T02%3A00%3A00${expectedOffsetStringEncoded}&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00${expectedOffsetStringEncoded}&subject=Birthday%20party`
       );
     });
 
     test("generate an all day outlook link", () => {
       const event: CalendarEvent = {
         title: "Birthday party",
-        start: "2019-12-29Z",
+        start: "2019-12-29",
         allDay: true,
       };
+      const expectedOffsetString = dayjs(new Date()).format("Z");
+      const expectedOffsetStringEncoded = encodeURIComponent(expectedOffsetString);
       const link = outlook(event);
 
       expect(link).toBe(
-        "https://outlook.live.com/calendar/0/deeplink/compose?allday=true&enddt=2019-12-30T00%3A00%3A00%2B00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00%2B00%3A00&subject=Birthday%20party"
+        `https://outlook.live.com/calendar/0/deeplink/compose?allday=true&enddt=2019-12-30T00%3A00%3A00${expectedOffsetStringEncoded}&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00${expectedOffsetStringEncoded}&subject=Birthday%20party`
       );
     });
   });
@@ -163,26 +167,30 @@ describe("Calendar Links", () => {
     test("generate a office365 link", () => {
       const event: CalendarEvent = {
         title: "Birthday party",
-        start: "2019-12-29Z",
+        start: "2019-12-29",
         duration: [2, "hour"],
       };
+      const expectedOffsetString = dayjs(new Date()).format("Z");
+      const expectedOffsetStringEncoded = encodeURIComponent(expectedOffsetString);
       const link = office365(event);
 
       expect(link).toBe(
-        "https://outlook.office.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T02%3A00%3A00%2B00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00%2B00%3A00&subject=Birthday%20party"
+        `https://outlook.office.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T02%3A00%3A00${expectedOffsetStringEncoded}&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00${expectedOffsetStringEncoded}&subject=Birthday%20party`
       );
     });
 
     test("generate an all day office365 link", () => {
       const event: CalendarEvent = {
         title: "Birthday party",
-        start: "2019-12-29Z",
+        start: "2019-12-29",
         allDay: true,
       };
+      const expectedOffsetString = dayjs(new Date()).format("Z");
+      const expectedOffsetStringEncoded = encodeURIComponent(expectedOffsetString);
       const link = office365(event);
 
       expect(link).toBe(
-        "https://outlook.office.com/calendar/0/deeplink/compose?allday=true&enddt=2019-12-30T00%3A00%3A00%2B00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00%2B00%3A00&subject=Birthday%20party"
+        `https://outlook.office.com/calendar/0/deeplink/compose?allday=true&enddt=2019-12-30T00%3A00%3A00${expectedOffsetStringEncoded}&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00${expectedOffsetStringEncoded}&subject=Birthday%20party`
       );
     });
   });

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -138,12 +138,10 @@ describe("Calendar Links", () => {
         start: "2019-12-29",
         duration: [2, "hour"],
       };
-      const expectedOffsetString = dayjs(new Date()).format("Z");
-      const expectedOffsetStringEncoded = encodeURIComponent(expectedOffsetString);
       const link = outlook(event);
 
       expect(link).toBe(
-        `https://outlook.live.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T02%3A00%3A00${expectedOffsetStringEncoded}&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00${expectedOffsetStringEncoded}&subject=Birthday%20party`
+        `https://outlook.live.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party`
       );
     });
 
@@ -153,12 +151,10 @@ describe("Calendar Links", () => {
         start: "2019-12-29",
         allDay: true,
       };
-      const expectedOffsetString = dayjs(new Date()).format("Z");
-      const expectedOffsetStringEncoded = encodeURIComponent(expectedOffsetString);
       const link = outlook(event);
 
       expect(link).toBe(
-        `https://outlook.live.com/calendar/0/deeplink/compose?allday=true&enddt=2019-12-30T00%3A00%3A00${expectedOffsetStringEncoded}&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00${expectedOffsetStringEncoded}&subject=Birthday%20party`
+        `https://outlook.live.com/calendar/0/deeplink/compose?allday=true&enddt=2019-12-30T00%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party`
       );
     });
   });
@@ -170,12 +166,10 @@ describe("Calendar Links", () => {
         start: "2019-12-29",
         duration: [2, "hour"],
       };
-      const expectedOffsetString = dayjs(new Date()).format("Z");
-      const expectedOffsetStringEncoded = encodeURIComponent(expectedOffsetString);
       const link = office365(event);
 
       expect(link).toBe(
-        `https://outlook.office.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T02%3A00%3A00${expectedOffsetStringEncoded}&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00${expectedOffsetStringEncoded}&subject=Birthday%20party`
+        `https://outlook.office.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party`
       );
     });
 
@@ -185,12 +179,10 @@ describe("Calendar Links", () => {
         start: "2019-12-29",
         allDay: true,
       };
-      const expectedOffsetString = dayjs(new Date()).format("Z");
-      const expectedOffsetStringEncoded = encodeURIComponent(expectedOffsetString);
       const link = office365(event);
 
       expect(link).toBe(
-        `https://outlook.office.com/calendar/0/deeplink/compose?allday=true&enddt=2019-12-30T00%3A00%3A00${expectedOffsetStringEncoded}&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00${expectedOffsetStringEncoded}&subject=Birthday%20party`
+        `https://outlook.office.com/calendar/0/deeplink/compose?allday=true&enddt=2019-12-30T00%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party`
       );
     });
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,39 +2,48 @@ import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import { stringify } from "query-string";
 
-import { CalendarEvent, CalendarEventOrganizer, NormalizedCalendarEvent, Google, Outlook, Yahoo } from "./interfaces";
+import {
+  CalendarEvent,
+  CalendarEventOrganizer,
+  NormalizedCalendarEvent,
+  Google,
+  Outlook,
+  Yahoo,
+} from "./interfaces";
 import { TimeFormats } from "./utils";
 
 dayjs.extend(utc);
 
 function formatTimes(
-  { allDay, startUtc, endUtc }: NormalizedCalendarEvent,
+  { startTime, endTime }: NormalizedCalendarEvent,
   dateTimeFormat: keyof typeof TimeFormats
 ): { start: string; end: string } {
   const format = TimeFormats[dateTimeFormat];
-  return { start: startUtc.format(format), end: endUtc.format(format) };
+  return { start: startTime.format(format), end: endTime.format(format) };
 }
 
-export const eventify = (event: CalendarEvent): NormalizedCalendarEvent => {
+export const eventify = (event: CalendarEvent, toUtc: boolean = true): NormalizedCalendarEvent => {
   const { start, end, duration, ...rest } = event;
-  const startUtc = dayjs(start).utc();
-  const endUtc = end
-    ? dayjs(end).utc()
+  const startTime = toUtc ? dayjs(start).utc() : dayjs(start);
+  const endTime = end
+    ? toUtc
+      ? dayjs(end).utc()
+      : dayjs(end)
     : (() => {
         if (event.allDay) {
-          return startUtc.add(1, "day");
+          return startTime.add(1, "day");
         }
         if (duration && duration.length == 2) {
           const value = Number(duration[0]);
           const unit = duration[1];
-          return startUtc.add(value, unit);
+          return startTime.add(value, unit);
         }
-        return dayjs().utc();
+        return toUtc ? dayjs().utc() : dayjs();
       })();
   return {
     ...rest,
-    startUtc,
-    endUtc,
+    startTime: startTime,
+    endTime: endTime,
   };
 };
 
@@ -57,7 +66,7 @@ export const google = (calendarEvent: CalendarEvent): string => {
 };
 
 export const outlook = (calendarEvent: CalendarEvent): string => {
-  const event = eventify(calendarEvent);
+  const event = eventify(calendarEvent, false);
   const { start, end } = formatTimes(event, "dateTimeWithOffset");
   const details: Outlook = {
     path: "/calendar/action/compose",
@@ -67,13 +76,13 @@ export const outlook = (calendarEvent: CalendarEvent): string => {
     subject: event.title,
     body: event.description,
     location: event.location,
-    allday: event.allDay || false
+    allday: event.allDay || false,
   };
   return `https://outlook.live.com/calendar/0/deeplink/compose?${stringify(details)}`;
 };
 
 export const office365 = (calendarEvent: CalendarEvent): string => {
-  const event = eventify(calendarEvent);
+  const event = eventify(calendarEvent, false);
   const { start, end } = formatTimes(event, "dateTimeWithOffset");
   const details: Outlook = {
     path: "/calendar/action/compose",
@@ -83,7 +92,7 @@ export const office365 = (calendarEvent: CalendarEvent): string => {
     subject: event.title,
     body: event.description,
     location: event.location,
-    allday: event.allDay || false
+    allday: event.allDay || false,
   };
   return `https://outlook.office.com/calendar/0/deeplink/compose?${stringify(details)}`;
 };
@@ -98,7 +107,7 @@ export const yahoo = (calendarEvent: CalendarEvent): string => {
     et: end,
     desc: event.description,
     in_loc: event.location,
-    dur: event.allDay ? "allday" : false
+    dur: event.allDay ? "allday" : false,
   };
   return `https://calendar.yahoo.com/?${stringify(details)}`;
 };
@@ -181,7 +190,9 @@ export const ics = (calendarEvent: CalendarEvent): string => {
     if (chunk.value) {
       if (chunk.key == "ORGANIZER") {
         const value = chunk.value as CalendarEventOrganizer;
-        calendarUrl += `${chunk.key};${encodeURIComponent(`CN=${value.name}:MAILTO:${value.email}\n`)}`;
+        calendarUrl += `${chunk.key};${encodeURIComponent(
+          `CN=${value.name}:MAILTO:${value.email}\n`
+        )}`;
       } else {
         calendarUrl += `${chunk.key}:${encodeURIComponent(`${chunk.value}\n`)}`;
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,7 @@ export const google = (calendarEvent: CalendarEvent): string => {
 
 export const outlook = (calendarEvent: CalendarEvent): string => {
   const event = eventify(calendarEvent, false);
-  const { start, end } = formatTimes(event, "dateTimeWithOffset");
+  const { start, end } = formatTimes(event, "dateTimeLocal");
   const details: Outlook = {
     path: "/calendar/action/compose",
     rru: "addevent",
@@ -83,7 +83,7 @@ export const outlook = (calendarEvent: CalendarEvent): string => {
 
 export const office365 = (calendarEvent: CalendarEvent): string => {
   const event = eventify(calendarEvent, false);
-  const { start, end } = formatTimes(event, "dateTimeWithOffset");
+  const { start, end } = formatTimes(event, "dateTimeLocal");
   const details: Outlook = {
     path: "/calendar/action/compose",
     rru: "addevent",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -21,8 +21,8 @@ interface CalendarEventOrganizer {
 }
 
 interface NormalizedCalendarEvent extends Omit<CalendarEvent, "start" | "end" | "duration"> {
-  startUtc: dayjs.Dayjs;
-  endUtc: dayjs.Dayjs;
+  startTime: dayjs.Dayjs;
+  endTime: dayjs.Dayjs;
 }
 
 interface Google extends Record<string, string | boolean | number | undefined> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 export const TimeFormats = {
-  dateTimeWithOffset: "YYYY-MM-DD[T]HH:mm:ssZ",
+  dateTimeLocal: "YYYY-MM-DD[T]HH:mm:ss",
   dateTimeUTC: "YYYYMMDD[T]HHmmss[Z]",
   allDay: "YYYYMMDD",
 };


### PR DESCRIPTION
From our testing, it appears that Outlook and Office 365 will default the hour for the event based on the hour provided. 

Since the library currently converts all times to UTC, the events in these calendars are being placed at the wrong hour (unless you happen to be in the UTC timezone).

To fully support Outlook/Office365, the code needs to be changed to no longer convert to UTC but rather pass the local time without any offset in the URL.