### PR TITLE
Fix ics file generation (CLRF, absent fields: PRODID, UID, DTSTAMP)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -233,7 +233,7 @@ export const ics = (calendarEvent: CalendarEvent): string => {
     },
     {
       key: "UID",
-      value: Math.floor(Math.random() * 100),
+      value: Math.floor(Math.random() * 100000).toString().replace(".", ""),
     },
     {
       key: "END",

--- a/src/index.ts
+++ b/src/index.ts
@@ -177,6 +177,7 @@ export const ics = (calendarEvent: CalendarEvent): string => {
     .replace(/(\\n)[\s\t]+/gm, "\\n");
 
   const { start, end } = formatTimes(event, event.allDay ? "allDay" : "dateTimeUTC");
+  const dateStamp = dayjs(new Date()).utc().format(TimeFormats["dateTimeUTC"]);
   const calendarChunks = [
     {
       key: "BEGIN",
@@ -185,6 +186,10 @@ export const ics = (calendarEvent: CalendarEvent): string => {
     {
       key: "VERSION",
       value: "2.0",
+    },
+    {
+      key: "PRODID",
+      value: event.title
     },
     {
       key: "BEGIN",
@@ -201,6 +206,10 @@ export const ics = (calendarEvent: CalendarEvent): string => {
     {
       key: "DTEND",
       value: end,
+    },
+    {
+      key: "DTSTAMP",
+      value: dateStamp,
     },
     {
       key: "RRULE",
@@ -223,6 +232,10 @@ export const ics = (calendarEvent: CalendarEvent): string => {
       value: event.organizer,
     },
     {
+      key: "UID",
+      value: Math.floor(Math.random() * 100),
+    },
+    {
       key: "END",
       value: "VEVENT",
     },
@@ -239,10 +252,10 @@ export const ics = (calendarEvent: CalendarEvent): string => {
       if (chunk.key == "ORGANIZER") {
         const value = chunk.value as CalendarEventOrganizer;
         calendarUrl += `${chunk.key};${encodeURIComponent(
-          `CN=${value.name}:MAILTO:${value.email}\n`
+          `CN=${value.name}:MAILTO:${value.email}\r\n`
         )}`;
       } else {
-        calendarUrl += `${chunk.key}:${encodeURIComponent(`${chunk.value}\n`)}`;
+        calendarUrl += `${chunk.key}:${encodeURIComponent(`${chunk.value}\r\n`)}`;
       }
     }
   });


### PR DESCRIPTION
The library works perfectly with links creation, but I've found several issues when trying to create an ics file, it failed [iCalendar validation](https://icalendar.org/validator.html), so here are several suggestions that worked in my case:

- Changed \n to \r\n for the end of the line

- Added PRODID (as event name), UID (random), DTSTAMP (new Date())

![image](https://github.com/AnandChowdhary/calendar-link/assets/7937041/9dca297f-69b9-4df0-8bea-bfa887a4c72d)
