### PR TITLE
Add explicit types path to exports key in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,11 @@
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "exports": {
-    "import": "./dist/index.modern.mjs",
-    "require": "./dist/index.js"
+    ".": {
+      "import": "./dist/index.modern.mjs",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
   },
   "umd:main": "dist/index.umd.js",
   "files": [


### PR DESCRIPTION
Fixes #559

When adding this local variant to my yarn depedencies, type resolving seems to work fine again.