### PR TITLE
Fix Snapshot Tests for ICS Links

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,5 @@ module.exports = {
   preset: "ts-jest",
   globalSetup: "./jest-global-setup.js",
   testEnvironment: "node",
+  watchPathIgnorePatterns: ['node_modules'],
 };

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build:cjs": "tsc -m commonjs",
     "build": "run-p build:*",
     "test": "jest",
-    "test-watch": "jest --watchAll",
+    "test-watch": "jest --watch",
     "coverage": "jest --coverage",
     "update-template": "npx update-template https://github.com/AnandChowdhary/calendar-link",
     "semantic-release": "semantic-release"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build:cjs": "tsc -m commonjs",
     "build": "run-p build:*",
     "test": "jest",
-    "test-watch": "jest --watch",
+    "test-watch": "jest --watchAll",
     "coverage": "jest --coverage",
     "update-template": "npx update-template https://github.com/AnandChowdhary/calendar-link",
     "semantic-release": "semantic-release"

--- a/src/__snapshots__/index.spec.ts.snap
+++ b/src/__snapshots__/index.spec.ts.snap
@@ -1,97 +1,97 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`generate a aol link 1`] = `"https://calendar.aol.com/?dur=false&et=20191229T020000Z&st=20191229T000000Z&title=Birthday%20party&v=60"`;
+exports[`aol service generate a aol link 1`] = `"https://calendar.aol.com/?dur=false&et=20191229T020000Z&st=20191229T000000Z&title=Birthday%20party&v=60"`;
 
-exports[`generate a aol link with guests 1`] = `"https://calendar.aol.com/?dur=false&et=20191229T020000Z&st=20191229T000000Z&title=Birthday%20party&v=60"`;
+exports[`aol service generate a aol link with guests 1`] = `"https://calendar.aol.com/?dur=false&et=20191229T020000Z&st=20191229T000000Z&title=Birthday%20party&v=60"`;
 
-exports[`generate a aol link with time & timezone 1`] = `"https://calendar.aol.com/?dur=false&et=20191229T130000Z&st=20191229T110000Z&title=Birthday%20party&v=60"`;
+exports[`aol service generate a aol link with time & timezone 1`] = `"https://calendar.aol.com/?dur=false&et=20191229T130000Z&st=20191229T110000Z&title=Birthday%20party&v=60"`;
 
-exports[`generate a google link 1`] = `"https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20191229T000000Z%2F20191229T020000Z&text=Birthday%20party"`;
+exports[`aol service generate a multi day aol link 1`] = `"https://calendar.aol.com/?dur=allday&et=20200112&st=20191229&title=Birthday%20party&v=60"`;
 
-exports[`generate a google link with guests 1`] = `"https://calendar.google.com/calendar/render?action=TEMPLATE&add=hello%40example.com%2Canother%40example.com&dates=20191229T000000Z%2F20191229T020000Z&text=Birthday%20party"`;
+exports[`aol service generate a recurring aol link 1`] = `"https://calendar.aol.com/?dur=false&et=20191229T020000Z&st=20191229T000000Z&title=Birthday%20party&v=60"`;
 
-exports[`generate a google link with time & timezone 1`] = `"https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20191229T110000Z%2F20191229T130000Z&text=Birthday%20party"`;
+exports[`aol service generate an all day aol link 1`] = `"https://calendar.aol.com/?dur=allday&et=20191230&st=20191229&title=Birthday%20party&v=60"`;
 
-exports[`generate a ics link 1`] = `"data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0AVERSION:2.0%0ABEGIN:VEVENT%0ADTSTART:20191229T000000Z%0ADTEND:20191229T020000Z%0ASUMMARY:Birthday%20party%0AEND:VEVENT%0AEND:VCALENDAR%0A"`;
+exports[`google service generate a google link 1`] = `"https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20191229T000000Z%2F20191229T020000Z&text=Birthday%20party"`;
 
-exports[`generate a ics link with guests 1`] = `"data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0AVERSION:2.0%0ABEGIN:VEVENT%0ADTSTART:20191229T000000Z%0ADTEND:20191229T020000Z%0ASUMMARY:Birthday%20party%0AEND:VEVENT%0AEND:VCALENDAR%0A"`;
+exports[`google service generate a google link with guests 1`] = `"https://calendar.google.com/calendar/render?action=TEMPLATE&add=hello%40example.com%2Canother%40example.com&dates=20191229T000000Z%2F20191229T020000Z&text=Birthday%20party"`;
 
-exports[`generate a ics link with time & timezone 1`] = `"data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0AVERSION:2.0%0ABEGIN:VEVENT%0ADTSTART:20191229T110000Z%0ADTEND:20191229T130000Z%0ASUMMARY:Birthday%20party%0AEND:VEVENT%0AEND:VCALENDAR%0A"`;
+exports[`google service generate a google link with time & timezone 1`] = `"https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20191229T110000Z%2F20191229T130000Z&text=Birthday%20party"`;
 
-exports[`generate a multi day aol link 1`] = `"https://calendar.aol.com/?dur=allday&et=20200112&st=20191229&title=Birthday%20party&v=60"`;
+exports[`google service generate a multi day google link 1`] = `"https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20191229%2F20200112&text=Birthday%20party"`;
 
-exports[`generate a multi day google link 1`] = `"https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20191229%2F20200112&text=Birthday%20party"`;
+exports[`google service generate a recurring google link 1`] = `"https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20191229T000000Z%2F20191229T020000Z&recur=RRULE%3AFREQ%3DYEARLY%3BINTERVAL%3D1&text=Birthday%20party"`;
 
-exports[`generate a multi day ics link 1`] = `"data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0AVERSION:2.0%0ABEGIN:VEVENT%0ADTSTART:20191229%0ADTEND:20200112%0ASUMMARY:Birthday%20party%0AEND:VEVENT%0AEND:VCALENDAR%0A"`;
+exports[`google service generate an all day google link 1`] = `"https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20191229%2F20191230&text=Birthday%20party"`;
 
-exports[`generate a multi day office365 link 1`] = `"https://outlook.office.com/calendar/0/action/compose?allday=true&enddt=2020-01-12T00%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
+exports[`ics service generate a ics link 1`] = `"data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0D%0AVERSION:2.0%0D%0APRODID:Birthday%20party%0D%0ABEGIN:VEVENT%0D%0ADTSTART:20191229T000000Z%0D%0ADTEND:20191229T020000Z%0D%0ADTSTAMP:20191228T120000Z%0D%0ASUMMARY:Birthday%20party%0D%0AUID:12345%0D%0AEND:VEVENT%0D%0AEND:VCALENDAR%0D%0A"`;
 
-exports[`generate a multi day office365Mobile link 1`] = `"https://outlook.office.com/calendar/0/deeplink/compose?allday=true&enddt=2020-01-12T00%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
+exports[`ics service generate a ics link with guests 1`] = `"data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0D%0AVERSION:2.0%0D%0APRODID:Birthday%20party%0D%0ABEGIN:VEVENT%0D%0ADTSTART:20191229T000000Z%0D%0ADTEND:20191229T020000Z%0D%0ADTSTAMP:20191228T120000Z%0D%0ASUMMARY:Birthday%20party%0D%0AUID:12345%0D%0AEND:VEVENT%0D%0AEND:VCALENDAR%0D%0A"`;
 
-exports[`generate a multi day outlook link 1`] = `"https://outlook.live.com/calendar/0/action/compose?allday=true&enddt=2020-01-12T00%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
+exports[`ics service generate a ics link with time & timezone 1`] = `"data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0D%0AVERSION:2.0%0D%0APRODID:Birthday%20party%0D%0ABEGIN:VEVENT%0D%0ADTSTART:20191229T110000Z%0D%0ADTEND:20191229T130000Z%0D%0ADTSTAMP:20191228T120000Z%0D%0ASUMMARY:Birthday%20party%0D%0AUID:12345%0D%0AEND:VEVENT%0D%0AEND:VCALENDAR%0D%0A"`;
 
-exports[`generate a multi day outlookMobile link 1`] = `"https://outlook.live.com/calendar/0/deeplink/compose?allday=true&enddt=2020-01-12T00%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
+exports[`ics service generate a multi day ics link 1`] = `"data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0D%0AVERSION:2.0%0D%0APRODID:Birthday%20party%0D%0ABEGIN:VEVENT%0D%0ADTSTART:20191229%0D%0ADTEND:20200112%0D%0ADTSTAMP:20191228T120000Z%0D%0ASUMMARY:Birthday%20party%0D%0AUID:12345%0D%0AEND:VEVENT%0D%0AEND:VCALENDAR%0D%0A"`;
 
-exports[`generate a multi day yahoo link 1`] = `"https://calendar.yahoo.com/?dur=allday&et=20200112&st=20191229&title=Birthday%20party&v=60"`;
+exports[`ics service generate a recurring ics link 1`] = `"data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0D%0AVERSION:2.0%0D%0APRODID:Birthday%20party%0D%0ABEGIN:VEVENT%0D%0ADTSTART:20191229T000000Z%0D%0ADTEND:20191229T020000Z%0D%0ADTSTAMP:20191228T120000Z%0D%0ARRULE:FREQ%3DYEARLY%3BINTERVAL%3D1%0D%0ASUMMARY:Birthday%20party%0D%0AUID:12345%0D%0AEND:VEVENT%0D%0AEND:VCALENDAR%0D%0A"`;
 
-exports[`generate a office365 link 1`] = `"https://outlook.office.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
+exports[`ics service generate an all day ics link 1`] = `"data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0D%0AVERSION:2.0%0D%0APRODID:Birthday%20party%0D%0ABEGIN:VEVENT%0D%0ADTSTART:20191229%0D%0ADTEND:20191230%0D%0ADTSTAMP:20191228T120000Z%0D%0ASUMMARY:Birthday%20party%0D%0AUID:12345%0D%0AEND:VEVENT%0D%0AEND:VCALENDAR%0D%0A"`;
 
-exports[`generate a office365 link with guests 1`] = `"https://outlook.office.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
+exports[`office365 service generate a multi day office365 link 1`] = `"https://outlook.office.com/calendar/0/action/compose?allday=true&enddt=2020-01-12T00%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
-exports[`generate a office365 link with time & timezone 1`] = `"https://outlook.office.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T13%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T11%3A00%3A00&subject=Birthday%20party"`;
+exports[`office365 service generate a office365 link 1`] = `"https://outlook.office.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
-exports[`generate a office365Mobile link 1`] = `"https://outlook.office.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
+exports[`office365 service generate a office365 link with guests 1`] = `"https://outlook.office.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
-exports[`generate a office365Mobile link with guests 1`] = `"https://outlook.office.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
+exports[`office365 service generate a office365 link with time & timezone 1`] = `"https://outlook.office.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T13%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T11%3A00%3A00&subject=Birthday%20party"`;
 
-exports[`generate a office365Mobile link with time & timezone 1`] = `"https://outlook.office.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T13%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T11%3A00%3A00&subject=Birthday%20party"`;
+exports[`office365 service generate a recurring office365 link 1`] = `"https://outlook.office.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
-exports[`generate a outlook link 1`] = `"https://outlook.live.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
+exports[`office365 service generate an all day office365 link 1`] = `"https://outlook.office.com/calendar/0/action/compose?allday=true&enddt=2019-12-30T00%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
-exports[`generate a outlook link with guests 1`] = `"https://outlook.live.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
+exports[`office365Mobile service generate a multi day office365Mobile link 1`] = `"https://outlook.office.com/calendar/0/deeplink/compose?allday=true&enddt=2020-01-12T00%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
-exports[`generate a outlook link with time & timezone 1`] = `"https://outlook.live.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T13%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T11%3A00%3A00&subject=Birthday%20party"`;
+exports[`office365Mobile service generate a office365Mobile link 1`] = `"https://outlook.office.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
-exports[`generate a outlookMobile link 1`] = `"https://outlook.live.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
+exports[`office365Mobile service generate a office365Mobile link with guests 1`] = `"https://outlook.office.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
-exports[`generate a outlookMobile link with guests 1`] = `"https://outlook.live.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
+exports[`office365Mobile service generate a office365Mobile link with time & timezone 1`] = `"https://outlook.office.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T13%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T11%3A00%3A00&subject=Birthday%20party"`;
 
-exports[`generate a outlookMobile link with time & timezone 1`] = `"https://outlook.live.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T13%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T11%3A00%3A00&subject=Birthday%20party"`;
+exports[`office365Mobile service generate a recurring office365Mobile link 1`] = `"https://outlook.office.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
-exports[`generate a recurring aol link 1`] = `"https://calendar.aol.com/?dur=false&et=20191229T020000Z&st=20191229T000000Z&title=Birthday%20party&v=60"`;
+exports[`office365Mobile service generate an all day office365Mobile link 1`] = `"https://outlook.office.com/calendar/0/deeplink/compose?allday=true&enddt=2019-12-30T00%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
-exports[`generate a recurring google link 1`] = `"https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20191229T000000Z%2F20191229T020000Z&recur=RRULE%3AFREQ%3DYEARLY%3BINTERVAL%3D1&text=Birthday%20party"`;
+exports[`outlook service generate a multi day outlook link 1`] = `"https://outlook.live.com/calendar/0/action/compose?allday=true&enddt=2020-01-12T00%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
-exports[`generate a recurring ics link 1`] = `"data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0AVERSION:2.0%0ABEGIN:VEVENT%0ADTSTART:20191229T000000Z%0ADTEND:20191229T020000Z%0ARRULE:FREQ%3DYEARLY%3BINTERVAL%3D1%0ASUMMARY:Birthday%20party%0AEND:VEVENT%0AEND:VCALENDAR%0A"`;
+exports[`outlook service generate a outlook link 1`] = `"https://outlook.live.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
-exports[`generate a recurring office365 link 1`] = `"https://outlook.office.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
+exports[`outlook service generate a outlook link with guests 1`] = `"https://outlook.live.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
-exports[`generate a recurring office365Mobile link 1`] = `"https://outlook.office.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
+exports[`outlook service generate a outlook link with time & timezone 1`] = `"https://outlook.live.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T13%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T11%3A00%3A00&subject=Birthday%20party"`;
 
-exports[`generate a recurring outlook link 1`] = `"https://outlook.live.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
+exports[`outlook service generate a recurring outlook link 1`] = `"https://outlook.live.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
-exports[`generate a recurring outlookMobile link 1`] = `"https://outlook.live.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
+exports[`outlook service generate an all day outlook link 1`] = `"https://outlook.live.com/calendar/0/action/compose?allday=true&enddt=2019-12-30T00%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
-exports[`generate a recurring yahoo link 1`] = `"https://calendar.yahoo.com/?dur=false&et=20191229T020000Z&st=20191229T000000Z&title=Birthday%20party&v=60"`;
+exports[`outlookMobile service generate a multi day outlookMobile link 1`] = `"https://outlook.live.com/calendar/0/deeplink/compose?allday=true&enddt=2020-01-12T00%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
-exports[`generate a yahoo link 1`] = `"https://calendar.yahoo.com/?dur=false&et=20191229T020000Z&st=20191229T000000Z&title=Birthday%20party&v=60"`;
+exports[`outlookMobile service generate a outlookMobile link 1`] = `"https://outlook.live.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
-exports[`generate a yahoo link with guests 1`] = `"https://calendar.yahoo.com/?dur=false&et=20191229T020000Z&st=20191229T000000Z&title=Birthday%20party&v=60"`;
+exports[`outlookMobile service generate a outlookMobile link with guests 1`] = `"https://outlook.live.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
-exports[`generate a yahoo link with time & timezone 1`] = `"https://calendar.yahoo.com/?dur=false&et=20191229T130000Z&st=20191229T110000Z&title=Birthday%20party&v=60"`;
+exports[`outlookMobile service generate a outlookMobile link with time & timezone 1`] = `"https://outlook.live.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T13%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T11%3A00%3A00&subject=Birthday%20party"`;
 
-exports[`generate an all day aol link 1`] = `"https://calendar.aol.com/?dur=allday&et=20191230&st=20191229&title=Birthday%20party&v=60"`;
+exports[`outlookMobile service generate a recurring outlookMobile link 1`] = `"https://outlook.live.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
-exports[`generate an all day google link 1`] = `"https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20191229%2F20191230&text=Birthday%20party"`;
+exports[`outlookMobile service generate an all day outlookMobile link 1`] = `"https://outlook.live.com/calendar/0/deeplink/compose?allday=true&enddt=2019-12-30T00%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
-exports[`generate an all day ics link 1`] = `"data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0AVERSION:2.0%0ABEGIN:VEVENT%0ADTSTART:20191229%0ADTEND:20191230%0ASUMMARY:Birthday%20party%0AEND:VEVENT%0AEND:VCALENDAR%0A"`;
+exports[`yahoo service generate a multi day yahoo link 1`] = `"https://calendar.yahoo.com/?dur=allday&et=20200112&st=20191229&title=Birthday%20party&v=60"`;
 
-exports[`generate an all day office365 link 1`] = `"https://outlook.office.com/calendar/0/action/compose?allday=true&enddt=2019-12-30T00%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
+exports[`yahoo service generate a recurring yahoo link 1`] = `"https://calendar.yahoo.com/?dur=false&et=20191229T020000Z&st=20191229T000000Z&title=Birthday%20party&v=60"`;
 
-exports[`generate an all day office365Mobile link 1`] = `"https://outlook.office.com/calendar/0/deeplink/compose?allday=true&enddt=2019-12-30T00%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
+exports[`yahoo service generate a yahoo link 1`] = `"https://calendar.yahoo.com/?dur=false&et=20191229T020000Z&st=20191229T000000Z&title=Birthday%20party&v=60"`;
 
-exports[`generate an all day outlook link 1`] = `"https://outlook.live.com/calendar/0/action/compose?allday=true&enddt=2019-12-30T00%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
+exports[`yahoo service generate a yahoo link with guests 1`] = `"https://calendar.yahoo.com/?dur=false&et=20191229T020000Z&st=20191229T000000Z&title=Birthday%20party&v=60"`;
 
-exports[`generate an all day outlookMobile link 1`] = `"https://outlook.live.com/calendar/0/deeplink/compose?allday=true&enddt=2019-12-30T00%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
+exports[`yahoo service generate a yahoo link with time & timezone 1`] = `"https://calendar.yahoo.com/?dur=false&et=20191229T130000Z&st=20191229T110000Z&title=Birthday%20party&v=60"`;
 
-exports[`generate an all day yahoo link 1`] = `"https://calendar.yahoo.com/?dur=allday&et=20191230&st=20191229&title=Birthday%20party&v=60"`;
+exports[`yahoo service generate an all day yahoo link 1`] = `"https://calendar.yahoo.com/?dur=allday&et=20191230&st=20191229&title=Birthday%20party&v=60"`;

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -20,67 +20,79 @@ for (const service of [
   outlookMobile,
   yahoo,
 ]) {
-  describe(`${service.name} service`, () => {});
-  test(`generate a ${service.name} link`, () => {
-    const event: CalendarEvent = {
-      title: "Birthday party",
-      start: "2019-12-29",
-      duration: [2, "hour"],
-    };
-    const link = service(event);
-    expect(link).toMatchSnapshot();
+  beforeAll(() => {
+    jest.useFakeTimers("modern");
+    jest.setSystemTime(new Date("2019-12-28T12:00:00.000Z"));
+
+    jest.spyOn(global.Math, "random").mockReturnValue(0.12345);
   });
 
-  test(`generate a ${service.name} link with time & timezone`, () => {
-    const event: CalendarEvent = {
-      title: "Birthday party",
-      start: "2019-12-29T12:00:00.000+01:00",
-      duration: [2, "hour"],
-    };
-    const link = service(event);
-    expect(link).toMatchSnapshot();
+  afterAll(() => {
+    jest.useRealTimers();
   });
 
-  test(`generate an all day ${service.name} link`, () => {
-    const event: CalendarEvent = {
-      title: "Birthday party",
-      start: "2019-12-29",
-      allDay: true,
-    };
-    const link = service(event);
-    expect(link).toMatchSnapshot();
-  });
+  describe(`${service.name} service`, () => {
+    test(`generate a ${service.name} link`, () => {
+      const event: CalendarEvent = {
+        title: "Birthday party",
+        start: "2019-12-29",
+        duration: [2, "hour"],
+      };
+      const link = service(event);
+      expect(link).toMatchSnapshot();
+    });
 
-  test(`generate a multi day ${service.name} link`, () => {
-    const event: CalendarEvent = {
-      title: "Birthday party",
-      start: "2019-12-29",
-      end: "2020-01-12",
-      allDay: true,
-    };
-    const link = service(event);
-    expect(link).toMatchSnapshot();
-  });
+    test(`generate a ${service.name} link with time & timezone`, () => {
+      const event: CalendarEvent = {
+        title: "Birthday party",
+        start: "2019-12-29T12:00:00.000+01:00",
+        duration: [2, "hour"],
+      };
+      const link = service(event);
+      expect(link).toMatchSnapshot();
+    });
 
-  test(`generate a recurring ${service.name} link`, () => {
-    const event: CalendarEvent = {
-      title: "Birthday party",
-      start: "2019-12-29",
-      duration: [2, "hour"],
-      rRule: "FREQ=YEARLY;INTERVAL=1",
-    };
-    const link = service(event);
-    expect(link).toMatchSnapshot();
-  });
+    test(`generate an all day ${service.name} link`, () => {
+      const event: CalendarEvent = {
+        title: "Birthday party",
+        start: "2019-12-29",
+        allDay: true,
+      };
+      const link = service(event);
+      expect(link).toMatchSnapshot();
+    });
 
-  test(`generate a ${service.name} link with guests`, () => {
-    const event: CalendarEvent = {
-      title: "Birthday party",
-      start: "2019-12-29",
-      duration: [2, "hour"],
-      guests: ["hello@example.com", "another@example.com"],
-    };
-    const link = service(event);
-    expect(link).toMatchSnapshot();
+    test(`generate a multi day ${service.name} link`, () => {
+      const event: CalendarEvent = {
+        title: "Birthday party",
+        start: "2019-12-29",
+        end: "2020-01-12",
+        allDay: true,
+      };
+      const link = service(event);
+      expect(link).toMatchSnapshot();
+    });
+
+    test(`generate a recurring ${service.name} link`, () => {
+      const event: CalendarEvent = {
+        title: "Birthday party",
+        start: "2019-12-29",
+        duration: [2, "hour"],
+        rRule: "FREQ=YEARLY;INTERVAL=1",
+      };
+      const link = service(event);
+      expect(link).toMatchSnapshot();
+    });
+
+    test(`generate a ${service.name} link with guests`, () => {
+      const event: CalendarEvent = {
+        title: "Birthday party",
+        start: "2019-12-29",
+        duration: [2, "hour"],
+        guests: ["hello@example.com", "another@example.com"],
+      };
+      const link = service(event);
+      expect(link).toMatchSnapshot();
+    });
   });
 }


### PR DESCRIPTION
**Description:**

This PR addresses the issues causing snapshot mismatches in the ics link generator tests. The following changes have been made to ensure the tests pass consistently:

1. **Fixed `DTSTAMP` Property:**
   - Introduced a fixed system time for Jest tests using `jest.setSystemTime` and setting a constant date in a `beforeAll` block. This prevents the `DTSTAMP` property from changing with every test run.

2. **Stable `UID` Property:**
   - Mocked `Math.random` to return a consistent value during tests. This ensures the `UID` property remains the same across test runs, resolving issues with snapshot testing.

3. **Consistent Line Endings:**
   - Updated snapshots to use consistent line endings (`%0D%0A` for CRLF) in alignment with the changes made in PR [#553](https://github.com/AnandChowdhary/calendar-link/pull/553). This ensures the generated ics links match the expected format in the snapshots.

4. **Included Missing `PRODID` Property:**
   - Updated snapshots to include the newly added `PRODID` property, reflecting the latest structure of the ics links.

**Changes Made:**

- **Organized Tests with `describe` Blocks:**
  - Wrapped each service test in a `describe` block for better organization and clarity. This helps in identifying which test failed and which service it relates to.

**Testing:**

- Ran `npm test` to verify that all snapshot tests pass with the new configurations.
- Confirmed that the snapshots match the expected output with fixed `DTSTAMP`, consistent `UID`, correct line endings, and included `PRODID`.