### PR TITLE
Add Microsoft Teams Calendar Event Generation Feature

### DIFF
--- a/src/__snapshots__/index.spec.ts.snap
+++ b/src/__snapshots__/index.spec.ts.snap
@@ -2,6 +2,8 @@
 
 exports[`aol service generate a aol link 1`] = `"https://calendar.aol.com/?dur=false&et=20191229T020000Z&st=20191229T000000Z&title=Birthday%20party&v=60"`;
 
+exports[`aol service generate a aol link with description 1`] = `"https://calendar.aol.com/?desc=Bring%20gifts%21&dur=false&et=20191229T020000Z&st=20191229T000000Z&title=Birthday%20party&v=60"`;
+
 exports[`aol service generate a aol link with guests 1`] = `"https://calendar.aol.com/?dur=false&et=20191229T020000Z&st=20191229T000000Z&title=Birthday%20party&v=60"`;
 
 exports[`aol service generate a aol link with time & timezone 1`] = `"https://calendar.aol.com/?dur=false&et=20191229T130000Z&st=20191229T110000Z&title=Birthday%20party&v=60"`;
@@ -13,6 +15,8 @@ exports[`aol service generate a recurring aol link 1`] = `"https://calendar.aol.
 exports[`aol service generate an all day aol link 1`] = `"https://calendar.aol.com/?dur=allday&et=20191230&st=20191229&title=Birthday%20party&v=60"`;
 
 exports[`google service generate a google link 1`] = `"https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20191229T000000Z%2F20191229T020000Z&text=Birthday%20party"`;
+
+exports[`google service generate a google link with description 1`] = `"https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20191229T000000Z%2F20191229T020000Z&details=Bring%20gifts%21&text=Birthday%20party"`;
 
 exports[`google service generate a google link with guests 1`] = `"https://calendar.google.com/calendar/render?action=TEMPLATE&add=hello%40example.com%2Canother%40example.com&dates=20191229T000000Z%2F20191229T020000Z&text=Birthday%20party"`;
 
@@ -26,6 +30,8 @@ exports[`google service generate an all day google link 1`] = `"https://calendar
 
 exports[`ics service generate a ics link 1`] = `"data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0D%0AVERSION:2.0%0D%0APRODID:Birthday%20party%0D%0ABEGIN:VEVENT%0D%0ADTSTART:20191229T000000Z%0D%0ADTEND:20191229T020000Z%0D%0ADTSTAMP:20191228T120000Z%0D%0ASUMMARY:Birthday%20party%0D%0AUID:12345%0D%0AEND:VEVENT%0D%0AEND:VCALENDAR%0D%0A"`;
 
+exports[`ics service generate a ics link with description 1`] = `"data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0D%0AVERSION:2.0%0D%0APRODID:Birthday%20party%0D%0ABEGIN:VEVENT%0D%0ADTSTART:20191229T000000Z%0D%0ADTEND:20191229T020000Z%0D%0ADTSTAMP:20191228T120000Z%0D%0ASUMMARY:Birthday%20party%0D%0ADESCRIPTION:Bring%20gifts!%0D%0AUID:12345%0D%0AEND:VEVENT%0D%0AEND:VCALENDAR%0D%0A"`;
+
 exports[`ics service generate a ics link with guests 1`] = `"data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0D%0AVERSION:2.0%0D%0APRODID:Birthday%20party%0D%0ABEGIN:VEVENT%0D%0ADTSTART:20191229T000000Z%0D%0ADTEND:20191229T020000Z%0D%0ADTSTAMP:20191228T120000Z%0D%0ASUMMARY:Birthday%20party%0D%0AUID:12345%0D%0AEND:VEVENT%0D%0AEND:VCALENDAR%0D%0A"`;
 
 exports[`ics service generate a ics link with time & timezone 1`] = `"data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0D%0AVERSION:2.0%0D%0APRODID:Birthday%20party%0D%0ABEGIN:VEVENT%0D%0ADTSTART:20191229T110000Z%0D%0ADTEND:20191229T130000Z%0D%0ADTSTAMP:20191228T120000Z%0D%0ASUMMARY:Birthday%20party%0D%0AUID:12345%0D%0AEND:VEVENT%0D%0AEND:VCALENDAR%0D%0A"`;
@@ -36,9 +42,25 @@ exports[`ics service generate a recurring ics link 1`] = `"data:text/calendar;ch
 
 exports[`ics service generate an all day ics link 1`] = `"data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0D%0AVERSION:2.0%0D%0APRODID:Birthday%20party%0D%0ABEGIN:VEVENT%0D%0ADTSTART:20191229%0D%0ADTEND:20191230%0D%0ADTSTAMP:20191228T120000Z%0D%0ASUMMARY:Birthday%20party%0D%0AUID:12345%0D%0AEND:VEVENT%0D%0AEND:VCALENDAR%0D%0A"`;
 
+exports[`msTeams service generate a msTeams link 1`] = `"https://teams.microsoft.com/l/meeting/new?endTime=2019-12-29T02%3A00%3A00.000Z&startTime=2019-12-29T00%3A00%3A00.000Z&subject=Birthday%20party"`;
+
+exports[`msTeams service generate a msTeams link with description 1`] = `"https://teams.microsoft.com/l/meeting/new?content=Bring%20gifts%21&endTime=2019-12-29T02%3A00%3A00.000Z&startTime=2019-12-29T00%3A00%3A00.000Z&subject=Birthday%20party"`;
+
+exports[`msTeams service generate a msTeams link with guests 1`] = `"https://teams.microsoft.com/l/meeting/new?endTime=2019-12-29T02%3A00%3A00.000Z&startTime=2019-12-29T00%3A00%3A00.000Z&subject=Birthday%20party"`;
+
+exports[`msTeams service generate a msTeams link with time & timezone 1`] = `"https://teams.microsoft.com/l/meeting/new?endTime=2019-12-29T13%3A00%3A00.000Z&startTime=2019-12-29T11%3A00%3A00.000Z&subject=Birthday%20party"`;
+
+exports[`msTeams service generate a multi day msTeams link 1`] = `"https://teams.microsoft.com/l/meeting/new?endTime=2020-01-12T00%3A00%3A00.000Z&startTime=2019-12-29T00%3A00%3A00.000Z&subject=Birthday%20party"`;
+
+exports[`msTeams service generate a recurring msTeams link 1`] = `"https://teams.microsoft.com/l/meeting/new?endTime=2019-12-29T02%3A00%3A00.000Z&startTime=2019-12-29T00%3A00%3A00.000Z&subject=Birthday%20party"`;
+
+exports[`msTeams service generate an all day msTeams link 1`] = `"https://teams.microsoft.com/l/meeting/new?endTime=2019-12-30T00%3A00%3A00.000Z&startTime=2019-12-29T00%3A00%3A00.000Z&subject=Birthday%20party"`;
+
 exports[`office365 service generate a multi day office365 link 1`] = `"https://outlook.office.com/calendar/0/action/compose?allday=true&enddt=2020-01-12T00%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
 exports[`office365 service generate a office365 link 1`] = `"https://outlook.office.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
+
+exports[`office365 service generate a office365 link with description 1`] = `"https://outlook.office.com/calendar/0/action/compose?allday=false&body=Bring%20gifts%21&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
 exports[`office365 service generate a office365 link with guests 1`] = `"https://outlook.office.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
@@ -52,6 +74,8 @@ exports[`office365Mobile service generate a multi day office365Mobile link 1`] =
 
 exports[`office365Mobile service generate a office365Mobile link 1`] = `"https://outlook.office.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
+exports[`office365Mobile service generate a office365Mobile link with description 1`] = `"https://outlook.office.com/calendar/0/deeplink/compose?allday=false&body=Bring%20gifts%21&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
+
 exports[`office365Mobile service generate a office365Mobile link with guests 1`] = `"https://outlook.office.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
 exports[`office365Mobile service generate a office365Mobile link with time & timezone 1`] = `"https://outlook.office.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T13%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T11%3A00%3A00&subject=Birthday%20party"`;
@@ -64,6 +88,8 @@ exports[`outlook service generate a multi day outlook link 1`] = `"https://outlo
 
 exports[`outlook service generate a outlook link 1`] = `"https://outlook.live.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
+exports[`outlook service generate a outlook link with description 1`] = `"https://outlook.live.com/calendar/0/action/compose?allday=false&body=Bring%20gifts%21&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
+
 exports[`outlook service generate a outlook link with guests 1`] = `"https://outlook.live.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
 exports[`outlook service generate a outlook link with time & timezone 1`] = `"https://outlook.live.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T13%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T11%3A00%3A00&subject=Birthday%20party"`;
@@ -75,6 +101,8 @@ exports[`outlook service generate an all day outlook link 1`] = `"https://outloo
 exports[`outlookMobile service generate a multi day outlookMobile link 1`] = `"https://outlook.live.com/calendar/0/deeplink/compose?allday=true&enddt=2020-01-12T00%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
 exports[`outlookMobile service generate a outlookMobile link 1`] = `"https://outlook.live.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
+
+exports[`outlookMobile service generate a outlookMobile link with description 1`] = `"https://outlook.live.com/calendar/0/deeplink/compose?allday=false&body=Bring%20gifts%21&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
 exports[`outlookMobile service generate a outlookMobile link with guests 1`] = `"https://outlook.live.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
@@ -89,6 +117,8 @@ exports[`yahoo service generate a multi day yahoo link 1`] = `"https://calendar.
 exports[`yahoo service generate a recurring yahoo link 1`] = `"https://calendar.yahoo.com/?dur=false&et=20191229T020000Z&st=20191229T000000Z&title=Birthday%20party&v=60"`;
 
 exports[`yahoo service generate a yahoo link 1`] = `"https://calendar.yahoo.com/?dur=false&et=20191229T020000Z&st=20191229T000000Z&title=Birthday%20party&v=60"`;
+
+exports[`yahoo service generate a yahoo link with description 1`] = `"https://calendar.yahoo.com/?desc=Bring%20gifts%21&dur=false&et=20191229T020000Z&st=20191229T000000Z&title=Birthday%20party&v=60"`;
 
 exports[`yahoo service generate a yahoo link with guests 1`] = `"https://calendar.yahoo.com/?dur=false&et=20191229T020000Z&st=20191229T000000Z&title=Birthday%20party&v=60"`;
 

--- a/src/__snapshots__/index.spec.ts.snap
+++ b/src/__snapshots__/index.spec.ts.snap
@@ -46,7 +46,7 @@ exports[`msTeams service generate a msTeams link 1`] = `"https://teams.microsoft
 
 exports[`msTeams service generate a msTeams link with description 1`] = `"https://teams.microsoft.com/l/meeting/new?content=Bring%20gifts%21&endTime=2019-12-29T02%3A00%3A00.000Z&startTime=2019-12-29T00%3A00%3A00.000Z&subject=Birthday%20party"`;
 
-exports[`msTeams service generate a msTeams link with guests 1`] = `"https://teams.microsoft.com/l/meeting/new?endTime=2019-12-29T02%3A00%3A00.000Z&startTime=2019-12-29T00%3A00%3A00.000Z&subject=Birthday%20party"`;
+exports[`msTeams service generate a msTeams link with guests 1`] = `"https://teams.microsoft.com/l/meeting/new?attendees=hello%40example.com%2Canother%40example.com&endTime=2019-12-29T02%3A00%3A00.000Z&startTime=2019-12-29T00%3A00%3A00.000Z&subject=Birthday%20party"`;
 
 exports[`msTeams service generate a msTeams link with time & timezone 1`] = `"https://teams.microsoft.com/l/meeting/new?endTime=2019-12-29T13%3A00%3A00.000Z&startTime=2019-12-29T11%3A00%3A00.000Z&subject=Birthday%20party"`;
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -2,6 +2,7 @@ import {
   aol,
   google,
   ics,
+  msTeams,
   office365,
   office365Mobile,
   outlook,
@@ -14,6 +15,7 @@ for (const service of [
   aol,
   google,
   ics,
+  msTeams,
   office365,
   office365Mobile,
   outlook,
@@ -37,6 +39,17 @@ for (const service of [
         title: "Birthday party",
         start: "2019-12-29",
         duration: [2, "hour"],
+      };
+      const link = service(event);
+      expect(link).toMatchSnapshot();
+    });
+
+    test(`generate a ${service.name} link with description`, () => {
+      const event: CalendarEvent = {
+        title: "Birthday party",
+        start: "2019-12-29",
+        duration: [2, "hour"],
+        description: "Bring gifts!",
       };
       const link = service(event);
       expect(link).toMatchSnapshot();

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import {
   NormalizedCalendarEvent,
   Aol,
   Google,
+  MsTeams,
   Outlook,
   Yahoo,
 } from "./interfaces";
@@ -158,6 +159,17 @@ export const aol = (calendarEvent: CalendarEvent): string => {
       dur: event.allDay ? "allday" : false,
     };
     return `https://calendar.aol.com/?${stringify(details)}`;
+};
+
+export const msTeams = (calendarEvent: CalendarEvent): string => {
+  const event = eventify(calendarEvent);
+  const details: MsTeams = {
+    subject: event.title,
+    content: event.description,
+    startTime: event.startTime.toISOString(),
+    endTime: event.endTime.toISOString(),
+  };
+  return `https://teams.microsoft.com/l/meeting/new?${stringify(details)}`;
 };
 
 export const ics = (calendarEvent: CalendarEvent): string => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -161,6 +161,7 @@ export const aol = (calendarEvent: CalendarEvent): string => {
     return `https://calendar.aol.com/?${stringify(details)}`;
 };
 
+// https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/build-and-test/deep-link-workflow?tabs=teamsjs-v2#configure-deep-link-manually-to-open-a-meeting-scheduling-dialog
 export const msTeams = (calendarEvent: CalendarEvent): string => {
   const event = eventify(calendarEvent);
   const details: MsTeams = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,6 +169,9 @@ export const msTeams = (calendarEvent: CalendarEvent): string => {
     startTime: event.startTime.toISOString(),
     endTime: event.endTime.toISOString(),
   };
+  if (event.guests && event.guests.length) {
+    details.attendees = event.guests.join();
+  }
   return `https://teams.microsoft.com/l/meeting/new?${stringify(details)}`;
 };
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -67,4 +67,12 @@ interface Aol extends Record<string, string | boolean | number | undefined> {
     in_loc?: string;
  }
 
-export { CalendarEvent, CalendarEventOrganizer, NormalizedCalendarEvent, Outlook, Yahoo, Google, Aol };
+interface MsTeams extends Record<string, string | boolean | number | undefined> {
+  subject?: string;
+  content?: string;
+  startTime?: string;
+  endTime?: string;
+  attendees?: string;
+}
+
+export { CalendarEvent, CalendarEventOrganizer, NormalizedCalendarEvent, Outlook, Yahoo, Google, Aol, MsTeams };


### PR DESCRIPTION
**Feature Description:**
This PR introduces the ability to generate links for creating Microsoft Teams calendar events using our calendar link generator package. The new feature utilizes the deep link configuration for Microsoft Teams, allowing users to easily create links that open a meeting scheduling dialog in Microsoft Teams. Resolves #598.

**Key Changes:**
1. **Microsoft Teams Event Generation:** Added functionality to generate Microsoft Teams calendar event links following the format specified in the [Microsoft Teams deep link documentation](https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/build-and-test/deep-link-workflow?tabs=teamsjs-v2#deep-link-to-open-a-meeting-scheduling-dialog).

**Testing:**
- Added Microsoft Teams to the test suite.
- Added a new test to verify that descriptions can be added to events and are correctly included in the generated links.

Please review the changes and let me know if there are any questions or further adjustments needed.