### PR TITLE
Remove query-string dependency (28% smaller bundle size)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ ics(event); // standard ICS file based on https://icalendar.org
 - If you don't pass the start and end time in UTC, Google will convert it to UTC but Outlook won't, so it's a good idea to use UTC when passing dates and times
 - There are some known issues in Office 365 because of which we can't generate a consistent link in all devices (#542)
 
+## Compatibility
+
+This package uses [URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) (Node.js >= 10, 97%+ browsers), but if you need to include a polyfill, you can include [url-search-params-polyfill](https://www.npmjs.com/package/url-search-params-polyfill) first.
+
 ## License
 
 MIT © [Anand Chowdhary](https://anandchowdhary.com/?utm_source=github&utm_medium=calendar-link&utm_campaign=readme)

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,11 +6,10 @@
   "packages": {
     "": {
       "name": "calendar-link",
-      "version": "2.4.0",
+      "version": "2.7.0",
       "license": "MIT",
       "dependencies": {
-        "dayjs": "^1.9.3",
-        "query-string": "^6.13.6"
+        "dayjs": "^1.9.3"
       },
       "devDependencies": {
         "@koj/config": "1.2.11",
@@ -5142,6 +5141,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -6153,14 +6153,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/filter-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
-      "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs=",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/find-cache-dir": {
@@ -19171,23 +19163,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/query-string": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.1.tgz",
-      "integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
-      "dependencies": {
-        "decode-uri-component": "^0.2.0",
-        "filter-obj": "^1.1.0",
-        "split-on-first": "^1.0.0",
-        "strict-uri-encode": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/quick-lru": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
@@ -21180,14 +21155,6 @@
         "node": "*"
       }
     },
-    "node_modules/split-on-first": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
-      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -21325,14 +21292,6 @@
       "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/strict-uri-encode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/string_decoder": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "typescript": "^4.0.3"
   },
   "dependencies": {
-    "dayjs": "^1.9.3",
-    "query-string": "^6.13.6"
+    "dayjs": "^1.9.3"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
-import { stringify } from "query-string";
 
 import {
   CalendarEvent,
@@ -15,6 +14,19 @@ import {
 import { TimeFormats } from "./utils";
 
 dayjs.extend(utc);
+
+function stringify(input: Record<string, any>): string {
+  const params = new URLSearchParams();
+  Object.keys(input)
+    .sort()
+    .forEach((key) => {
+      const value = input[key];
+      if (value != null) {
+        params.append(key, value);
+      }
+    });
+  return params.toString().replace(/\+/g, "%20");
+}
 
 function formatTimes(
   { startTime, endTime }: NormalizedCalendarEvent,


### PR DESCRIPTION
# Description

Remove `query-string` dependency from `calendar-link`

# Goal

Limit the number of dependencies to:
* improve maintainability
* reduce bundle size

# File size

Approximately 28% smaller:

## Before

```
      6.54 kB: index.modern.mjs.gz
      5.92 kB: index.modern.mjs.br
      6.55 kB: index.umd.js.gz
      5.94 kB: index.umd.js.br
```

## After

```
      4.70 kB: index.modern.mjs.gz
      4.23 kB: index.modern.mjs.br
      4.70 kB: index.umd.js.gz
      4.25 kB: index.umd.js.br
```

# Notes

In order to keep parity with previous behavior, we had to:
* Sort the keys of the object alphabetically 
* Filter out `null` and `undefined` values
* Replace `+` with `%20` in the URL to specify spaces

Apart from the filtering of `null` and `undefined` values, none of these are strictly necessary, they just made the tests pass.

# Support for `URLSearchParams`

* [Node.js >= 10](https://nodejs.org/api/url.html#class-urlsearchparams): [current lts version is 20.10](https://nodejs.org/en/about/previous-releases)
* [97%+ browsers](https://caniuse.com/?search=URLSearchParams): Only Opera mini / IE11 don't support it