### PR TITLE
Support start/end timezones for Google provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ ics(event); // standard ICS file based on https://icalendar.org
 | `busy`             | Mark on calendar as busy?   | Boolean                                                                                                                                   |
 | `guests`           | Emails of other guests      | Array of emails (String)                                                                                                                  |
 | `url`              | Calendar document URL       | String                                                                                                                                    |
-| `stz`              | Start timezone              | String <br />**NOTE:** Only supported by `google`                                                                                         |
-| `etz`              | End timezone                | String <br />**NOTE:** Only supported by `google`                                                                                         |
+| `startTimeZone`    | Start timezone              | String <br />**NOTE:** Only supported by `google`                                                                                         |
+| `endTimeZone`      | End timezone                | String <br />**NOTE:** Only supported by `google`                                                                                         |
 
 #### Notes
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ ics(event); // standard ICS file based on https://icalendar.org
 | `busy`             | Mark on calendar as busy?   | Boolean                                                                                                                                   |
 | `guests`           | Emails of other guests      | Array of emails (String)                                                                                                                  |
 | `url`              | Calendar document URL       | String                                                                                                                                    |
+| `stz`              | Start timezone              | String <br />**NOTE:** Only supported by `google`                                                                                         |
+| `etz`              | End timezone                | String <br />**NOTE:** Only supported by `google`                                                                                         |
 
 #### Notes
 

--- a/src/__snapshots__/index.spec.ts.snap
+++ b/src/__snapshots__/index.spec.ts.snap
@@ -2,6 +2,8 @@
 
 exports[`aol service generate a aol link 1`] = `"https://calendar.aol.com/?dur=false&et=20191229T020000Z&st=20191229T000000Z&title=Birthday%20party&v=60"`;
 
+exports[`aol service generate a aol link different timezones 1`] = `"https://calendar.aol.com/?dur=false&et=20180405T160000Z&st=20180404T160000Z&title=Flight&v=60"`;
+
 exports[`aol service generate a aol link with description 1`] = `"https://calendar.aol.com/?desc=Bring%20gifts%21&dur=false&et=20191229T020000Z&st=20191229T000000Z&title=Birthday%20party&v=60"`;
 
 exports[`aol service generate a aol link with guests 1`] = `"https://calendar.aol.com/?dur=false&et=20191229T020000Z&st=20191229T000000Z&title=Birthday%20party&v=60"`;
@@ -15,6 +17,8 @@ exports[`aol service generate a recurring aol link 1`] = `"https://calendar.aol.
 exports[`aol service generate an all day aol link 1`] = `"https://calendar.aol.com/?dur=allday&et=20191230&st=20191229&title=Birthday%20party&v=60"`;
 
 exports[`google service generate a google link 1`] = `"https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20191229T000000Z%2F20191229T020000Z&text=Birthday%20party"`;
+
+exports[`google service generate a google link different timezones 1`] = `"https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20180404T160000Z%2F20180405T160000Z&etz=America%2FNew_York&stz=Europe%2FMadrid&text=Flight"`;
 
 exports[`google service generate a google link with description 1`] = `"https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20191229T000000Z%2F20191229T020000Z&details=Bring%20gifts%21&text=Birthday%20party"`;
 
@@ -30,6 +34,8 @@ exports[`google service generate an all day google link 1`] = `"https://calendar
 
 exports[`ics service generate a ics link 1`] = `"data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0D%0AVERSION:2.0%0D%0APRODID:Birthday%20party%0D%0ABEGIN:VEVENT%0D%0ADTSTART:20191229T000000Z%0D%0ADTEND:20191229T020000Z%0D%0ADTSTAMP:20191228T120000Z%0D%0ASUMMARY:Birthday%20party%0D%0AUID:12345%0D%0AEND:VEVENT%0D%0AEND:VCALENDAR%0D%0A"`;
 
+exports[`ics service generate a ics link different timezones 1`] = `"data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0D%0AVERSION:2.0%0D%0APRODID:Flight%0D%0ABEGIN:VEVENT%0D%0ADTSTART:20180404T160000Z%0D%0ADTEND:20180405T160000Z%0D%0ADTSTAMP:20191228T120000Z%0D%0ASUMMARY:Flight%0D%0AUID:12345%0D%0AEND:VEVENT%0D%0AEND:VCALENDAR%0D%0A"`;
+
 exports[`ics service generate a ics link with description 1`] = `"data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0D%0AVERSION:2.0%0D%0APRODID:Birthday%20party%0D%0ABEGIN:VEVENT%0D%0ADTSTART:20191229T000000Z%0D%0ADTEND:20191229T020000Z%0D%0ADTSTAMP:20191228T120000Z%0D%0ASUMMARY:Birthday%20party%0D%0ADESCRIPTION:Bring%20gifts!%0D%0AUID:12345%0D%0AEND:VEVENT%0D%0AEND:VCALENDAR%0D%0A"`;
 
 exports[`ics service generate a ics link with guests 1`] = `"data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0D%0AVERSION:2.0%0D%0APRODID:Birthday%20party%0D%0ABEGIN:VEVENT%0D%0ADTSTART:20191229T000000Z%0D%0ADTEND:20191229T020000Z%0D%0ADTSTAMP:20191228T120000Z%0D%0ASUMMARY:Birthday%20party%0D%0AUID:12345%0D%0AEND:VEVENT%0D%0AEND:VCALENDAR%0D%0A"`;
@@ -43,6 +49,8 @@ exports[`ics service generate a recurring ics link 1`] = `"data:text/calendar;ch
 exports[`ics service generate an all day ics link 1`] = `"data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0D%0AVERSION:2.0%0D%0APRODID:Birthday%20party%0D%0ABEGIN:VEVENT%0D%0ADTSTART:20191229%0D%0ADTEND:20191230%0D%0ADTSTAMP:20191228T120000Z%0D%0ASUMMARY:Birthday%20party%0D%0AUID:12345%0D%0AEND:VEVENT%0D%0AEND:VCALENDAR%0D%0A"`;
 
 exports[`msTeams service generate a msTeams link 1`] = `"https://teams.microsoft.com/l/meeting/new?endTime=2019-12-29T02%3A00%3A00.000Z&startTime=2019-12-29T00%3A00%3A00.000Z&subject=Birthday%20party"`;
+
+exports[`msTeams service generate a msTeams link different timezones 1`] = `"https://teams.microsoft.com/l/meeting/new?endTime=2018-04-05T16%3A00%3A00.000Z&startTime=2018-04-04T16%3A00%3A00.000Z&subject=Flight"`;
 
 exports[`msTeams service generate a msTeams link with description 1`] = `"https://teams.microsoft.com/l/meeting/new?content=Bring%20gifts%21&endTime=2019-12-29T02%3A00%3A00.000Z&startTime=2019-12-29T00%3A00%3A00.000Z&subject=Birthday%20party"`;
 
@@ -60,6 +68,8 @@ exports[`office365 service generate a multi day office365 link 1`] = `"https://o
 
 exports[`office365 service generate a office365 link 1`] = `"https://outlook.office.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
+exports[`office365 service generate a office365 link different timezones 1`] = `"https://outlook.office.com/calendar/0/action/compose?allday=false&enddt=2018-04-05T16%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2018-04-04T16%3A00%3A00&subject=Flight"`;
+
 exports[`office365 service generate a office365 link with description 1`] = `"https://outlook.office.com/calendar/0/action/compose?allday=false&body=Bring%20gifts%21&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
 exports[`office365 service generate a office365 link with guests 1`] = `"https://outlook.office.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
@@ -73,6 +83,8 @@ exports[`office365 service generate an all day office365 link 1`] = `"https://ou
 exports[`office365Mobile service generate a multi day office365Mobile link 1`] = `"https://outlook.office.com/calendar/0/deeplink/compose?allday=true&enddt=2020-01-12T00%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
 exports[`office365Mobile service generate a office365Mobile link 1`] = `"https://outlook.office.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
+
+exports[`office365Mobile service generate a office365Mobile link different timezones 1`] = `"https://outlook.office.com/calendar/0/deeplink/compose?allday=false&enddt=2018-04-05T16%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2018-04-04T16%3A00%3A00&subject=Flight"`;
 
 exports[`office365Mobile service generate a office365Mobile link with description 1`] = `"https://outlook.office.com/calendar/0/deeplink/compose?allday=false&body=Bring%20gifts%21&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
@@ -88,6 +100,8 @@ exports[`outlook service generate a multi day outlook link 1`] = `"https://outlo
 
 exports[`outlook service generate a outlook link 1`] = `"https://outlook.live.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
+exports[`outlook service generate a outlook link different timezones 1`] = `"https://outlook.live.com/calendar/0/action/compose?allday=false&enddt=2018-04-05T16%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2018-04-04T16%3A00%3A00&subject=Flight"`;
+
 exports[`outlook service generate a outlook link with description 1`] = `"https://outlook.live.com/calendar/0/action/compose?allday=false&body=Bring%20gifts%21&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
 exports[`outlook service generate a outlook link with guests 1`] = `"https://outlook.live.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
@@ -101,6 +115,8 @@ exports[`outlook service generate an all day outlook link 1`] = `"https://outloo
 exports[`outlookMobile service generate a multi day outlookMobile link 1`] = `"https://outlook.live.com/calendar/0/deeplink/compose?allday=true&enddt=2020-01-12T00%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
 exports[`outlookMobile service generate a outlookMobile link 1`] = `"https://outlook.live.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
+
+exports[`outlookMobile service generate a outlookMobile link different timezones 1`] = `"https://outlook.live.com/calendar/0/deeplink/compose?allday=false&enddt=2018-04-05T16%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2018-04-04T16%3A00%3A00&subject=Flight"`;
 
 exports[`outlookMobile service generate a outlookMobile link with description 1`] = `"https://outlook.live.com/calendar/0/deeplink/compose?allday=false&body=Bring%20gifts%21&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
@@ -117,6 +133,8 @@ exports[`yahoo service generate a multi day yahoo link 1`] = `"https://calendar.
 exports[`yahoo service generate a recurring yahoo link 1`] = `"https://calendar.yahoo.com/?dur=false&et=20191229T020000Z&st=20191229T000000Z&title=Birthday%20party&v=60"`;
 
 exports[`yahoo service generate a yahoo link 1`] = `"https://calendar.yahoo.com/?dur=false&et=20191229T020000Z&st=20191229T000000Z&title=Birthday%20party&v=60"`;
+
+exports[`yahoo service generate a yahoo link different timezones 1`] = `"https://calendar.yahoo.com/?dur=false&et=20180405T160000Z&st=20180404T160000Z&title=Flight&v=60"`;
 
 exports[`yahoo service generate a yahoo link with description 1`] = `"https://calendar.yahoo.com/?desc=Bring%20gifts%21&dur=false&et=20191229T020000Z&st=20191229T000000Z&title=Birthday%20party&v=60"`;
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -113,8 +113,8 @@ for (const service of [
         title: "Flight",
         start: "2018-04-04T16:00:00.000Z",
         end: "2018-04-05T16:00:00.000Z",
-        stz: "Europe/Madrid",
-        etz: "America/New_York",
+        startTimeZone: "Europe/Madrid",
+        endTimeZone: "America/New_York",
       };
       const link = service(event);
       expect(link).toMatchSnapshot();

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -107,5 +107,17 @@ for (const service of [
       const link = service(event);
       expect(link).toMatchSnapshot();
     });
+
+    test(`generate a ${service.name} link different timezones`, () => {
+      const event: CalendarEvent = {
+        title: "Flight",
+        start: "2018-04-04T16:00:00.000Z",
+        end: "2018-04-05T16:00:00.000Z",
+        stz: "Europe/Madrid",
+        etz: "America/New_York",
+      };
+      const link = service(event);
+      expect(link).toMatchSnapshot();
+    });
   });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ function stringify(input: Record<string, any>): string {
 
 function formatTimes(
   { startTime, endTime }: NormalizedCalendarEvent,
-  dateTimeFormat: keyof typeof TimeFormats
+  dateTimeFormat: keyof typeof TimeFormats,
 ): { start: string; end: string } {
   const format = TimeFormats[dateTimeFormat];
   return { start: startTime.format(format), end: endTime.format(format) };
@@ -161,18 +161,18 @@ export const yahoo = (calendarEvent: CalendarEvent): string => {
 };
 
 export const aol = (calendarEvent: CalendarEvent): string => {
-    const event = eventify(calendarEvent);
-    const { start, end } = formatTimes(event, event.allDay ? "allDay" : "dateTimeUTC");
-    const details: Aol = {
-      v: 60,
-      title: event.title,
-      st: start,
-      et: end,
-      desc: event.description,
-      in_loc: event.location,
-      dur: event.allDay ? "allday" : false,
-    };
-    return `https://calendar.aol.com/?${stringify(details)}`;
+  const event = eventify(calendarEvent);
+  const { start, end } = formatTimes(event, event.allDay ? "allDay" : "dateTimeUTC");
+  const details: Aol = {
+    v: 60,
+    title: event.title,
+    st: start,
+    et: end,
+    desc: event.description,
+    in_loc: event.location,
+    dur: event.allDay ? "allday" : false,
+  };
+  return `https://calendar.aol.com/?${stringify(details)}`;
 };
 
 // https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/build-and-test/deep-link-workflow?tabs=teamsjs-v2#configure-deep-link-manually-to-open-a-meeting-scheduling-dialog
@@ -219,7 +219,7 @@ export const ics = (calendarEvent: CalendarEvent): string => {
     },
     {
       key: "PRODID",
-      value: event.title
+      value: event.title,
     },
     {
       key: "BEGIN",
@@ -263,7 +263,9 @@ export const ics = (calendarEvent: CalendarEvent): string => {
     },
     {
       key: "UID",
-      value: Math.floor(Math.random() * 100000).toString().replace(".", ""),
+      value: Math.floor(Math.random() * 100000)
+        .toString()
+        .replace(".", ""),
     },
     {
       key: "END",
@@ -282,7 +284,7 @@ export const ics = (calendarEvent: CalendarEvent): string => {
       if (chunk.key == "ORGANIZER") {
         const value = chunk.value as CalendarEventOrganizer;
         calendarUrl += `${chunk.key};${encodeURIComponent(
-          `CN=${value.name}:MAILTO:${value.email}\r\n`
+          `CN=${value.name}:MAILTO:${value.email}\r\n`,
         )}`;
       } else {
         calendarUrl += `${chunk.key}:${encodeURIComponent(`${chunk.value}\r\n`)}`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,8 +72,8 @@ export const google = (calendarEvent: CalendarEvent): string => {
     trp: event.busy,
     dates: start + "/" + end,
     recur: event.rRule ? "RRULE:" + event.rRule : undefined,
-    stz: event.stz,
-    etz: event.etz,
+    stz: event.startTimeZone,
+    etz: event.endTimeZone,
   };
   if (event.guests && event.guests.length) {
     details.add = event.guests.join();

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,8 @@ export const google = (calendarEvent: CalendarEvent): string => {
     trp: event.busy,
     dates: start + "/" + end,
     recur: event.rRule ? "RRULE:" + event.rRule : undefined,
+    stz: event.stz,
+    etz: event.etz,
   };
   if (event.guests && event.guests.length) {
     details.add = event.guests.join();

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -63,13 +63,13 @@ interface Yahoo extends Record<string, string | boolean | number | undefined> {
 }
 
 interface Aol extends Record<string, string | boolean | number | undefined> {
-    v: number;
-    title: string;
-    st: string;
-    et: string;
-    desc?: string;
-    in_loc?: string;
- }
+  v: number;
+  title: string;
+  st: string;
+  et: string;
+  desc?: string;
+  in_loc?: string;
+}
 
 interface MsTeams extends Record<string, string | boolean | number | undefined> {
   subject?: string;
@@ -79,4 +79,13 @@ interface MsTeams extends Record<string, string | boolean | number | undefined> 
   attendees?: string;
 }
 
-export { CalendarEvent, CalendarEventOrganizer, NormalizedCalendarEvent, Outlook, Yahoo, Google, Aol, MsTeams };
+export {
+  CalendarEvent,
+  CalendarEventOrganizer,
+  NormalizedCalendarEvent,
+  Outlook,
+  Yahoo,
+  Google,
+  Aol,
+  MsTeams,
+};

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -13,6 +13,8 @@ interface CalendarEvent {
   busy?: boolean;
   guests?: string[];
   url?: string;
+  stz?: string;
+  etz?: string;
 }
 
 interface CalendarEventOrganizer {
@@ -36,6 +38,8 @@ interface Google extends Record<string, string | boolean | number | undefined> {
   add?: string;
   src?: string;
   recur?: string;
+  stz?: string;
+  etz?: string;
 }
 
 interface Outlook extends Record<string, string | boolean | number | undefined> {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -13,8 +13,8 @@ interface CalendarEvent {
   busy?: boolean;
   guests?: string[];
   url?: string;
-  stz?: string;
-  etz?: string;
+  startTimeZone?: string;
+  endTimeZone?: string;
 }
 
 interface CalendarEventOrganizer {


### PR DESCRIPTION

<img width="982" alt="image" src="https://github.com/user-attachments/assets/83457568-648d-4dde-ac12-f70987f1f3dc">



Additionally I did some minor formatting but we can discard that if you don't like it.

Off topic:
- Generally speaking I think it would make sense to use types over interfaces
- I don't think there should be a snapshot for providers which doesn't support an specific functionality
- start & end should have more restrictive types on a type level (even if that doesn't make any difference)
- Is there any reason not to use URL and any other related constructors to replace `stringify` fn?