### PR TITLE
Set ics PRODID correctly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -217,7 +217,7 @@ export const ics = (calendarEvent: CalendarEvent): string => {
     },
     {
       key: "PRODID",
-      value: event.title
+      value: "-//AnandChowdhary//calendar-link//EN"
     },
     {
       key: "BEGIN",


### PR DESCRIPTION
ics `PRODID` is supposed to identify who created the ICS file. The spec format is: `-//:vendor//:product//:language`

Example from another library: https://github.com/sebbo2002/ical-generator/blob/957a2bb238e71f534bbb7c9bafb39699b30fe5e2/src/calendar.ts#L127

(and the `-` prefix is added later: https://github.com/sebbo2002/ical-generator/blob/957a2bb238e71f534bbb7c9bafb39699b30fe5e2/src/calendar.ts#L741)