### PR TITLE
Events without end should not necessarily end "now"

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,15 +44,12 @@ export const eventify = (event: CalendarEvent, toUtc: boolean = true): Normalize
       ? dayjs(end).utc()
       : dayjs(end)
     : (() => {
-        if (event.allDay) {
-          return startTime.add(1, "day");
-        }
         if (duration && duration.length == 2) {
           const value = Number(duration[0]);
           const unit = duration[1];
           return startTime.add(value, unit);
         }
-        return toUtc ? dayjs().utc() : dayjs();
+        return startTime;
       })();
   return {
     ...rest,

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,9 @@ export const eventify = (event: CalendarEvent, toUtc: boolean = true): Normalize
       ? dayjs(end).utc()
       : dayjs(end)
     : (() => {
+        if (event.allDay) {
+          return startTime.add(1, "day");
+        }
         if (duration && duration.length == 2) {
           const value = Number(duration[0]);
           const unit = duration[1];


### PR DESCRIPTION
Currently if you create a "point in time" event, e.g. "5pm ET on Feb 17, 2026", this library assumes it ends "now"

This is particularly problematic for events that are in the future, because the generated event will have an end that comes before start, and be rejected from certain calendars

Instead, it seems safer to assume end matches start

An alternative (possibly preferred), would be to not send `end` at all if it's not supplied. This seemed like a larger refactor though