### PR TITLE
Support adding guests for outlook

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ ics(event); // standard ICS file based on https://icalendar.org
 | `description`      | Information about the event     | String                                                                                                                                    |
 | `location`         | Event location in words         | String                                                                                                                                    |
 | `busy`             | Mark on calendar as busy?       | Boolean                                                                                                                                   |
-| `guests`           | Emails of other guests          | Array of emails (String)                                                                                                                  |
+| `guests`           | Emails of other guests. This is currently only supported for `google`, `outlook`, `outlookMobile`, `office365`, `office365Mobile` and `msTeams`          | Array of emails (String)                                                                                                                  |
 | `url`              | Calendar document URL           | String                                                                                                                                    |
 | `uid`              | Unique identifier for the event | String                                                                                                                                    |
 
@@ -61,7 +61,7 @@ ics(event); // standard ICS file based on https://icalendar.org
 - Any one of the fields `end`, `duration`, or `allDay` is required.
 - The allowed units in `duration` are listed here: https://day.js.org/docs/en/durations/creating#list-of-all-available-units.
 - The `url` field defaults to `document.URL` if a global `document` object exists. For server-side rendering, you should supply the `url` manually.
-  Not all calendars support the `guests` and `url` fields.
+- Not all calendars support the `guests` and `url` fields. For `guests` support in outlook/office calendar, this has been tested with `outlook` and `office365` [when this PR was implemented](https://github.com/AnandChowdhary/calendar-link/pull/648) but we weren't able to test this with `outlookMobile` and `office365Mobile` so it might not work as expected. However, all outlook/office calendar links have same path and query string structure so we just added them as even if the query string is invalid, it will just be ignored and won't break anything.
 - If you don't pass the start and end time in UTC, Google will convert it to UTC but Outlook won't, so it's a good idea to use UTC when passing dates and times
 - There are some known issues in Office 365 because of which we can't generate a consistent link in all devices (#542)
 - The `uid` field is currently optional and will generate a random ID if not provided. In a future version, this field will be required to ensure proper event identification and deduplication.

--- a/src/__snapshots__/index.spec.ts.snap
+++ b/src/__snapshots__/index.spec.ts.snap
@@ -64,7 +64,7 @@ exports[`office365 service generate a office365 link 1`] = `"https://outlook.off
 
 exports[`office365 service generate a office365 link with description 1`] = `"https://outlook.office.com/calendar/0/action/compose?allday=false&body=Bring%20gifts%21&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
-exports[`office365 service generate a office365 link with guests 1`] = `"https://outlook.office.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
+exports[`office365 service generate a office365 link with guests 1`] = `"https://outlook.office.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party&to=hello%40example.com%2Canother%40example.com"`;
 
 exports[`office365 service generate a office365 link with time & timezone 1`] = `"https://outlook.office.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T13%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T11%3A00%3A00&subject=Birthday%20party"`;
 
@@ -78,7 +78,7 @@ exports[`office365Mobile service generate a office365Mobile link 1`] = `"https:/
 
 exports[`office365Mobile service generate a office365Mobile link with description 1`] = `"https://outlook.office.com/calendar/0/deeplink/compose?allday=false&body=Bring%20gifts%21&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
-exports[`office365Mobile service generate a office365Mobile link with guests 1`] = `"https://outlook.office.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
+exports[`office365Mobile service generate a office365Mobile link with guests 1`] = `"https://outlook.office.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party&to=hello%40example.com%2Canother%40example.com"`;
 
 exports[`office365Mobile service generate a office365Mobile link with time & timezone 1`] = `"https://outlook.office.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T13%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T11%3A00%3A00&subject=Birthday%20party"`;
 
@@ -92,7 +92,7 @@ exports[`outlook service generate a outlook link 1`] = `"https://outlook.live.co
 
 exports[`outlook service generate a outlook link with description 1`] = `"https://outlook.live.com/calendar/0/action/compose?allday=false&body=Bring%20gifts%21&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
-exports[`outlook service generate a outlook link with guests 1`] = `"https://outlook.live.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
+exports[`outlook service generate a outlook link with guests 1`] = `"https://outlook.live.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party&to=hello%40example.com%2Canother%40example.com"`;
 
 exports[`outlook service generate a outlook link with time & timezone 1`] = `"https://outlook.live.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T13%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T11%3A00%3A00&subject=Birthday%20party"`;
 
@@ -106,7 +106,7 @@ exports[`outlookMobile service generate a outlookMobile link 1`] = `"https://out
 
 exports[`outlookMobile service generate a outlookMobile link with description 1`] = `"https://outlook.live.com/calendar/0/deeplink/compose?allday=false&body=Bring%20gifts%21&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
-exports[`outlookMobile service generate a outlookMobile link with guests 1`] = `"https://outlook.live.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
+exports[`outlookMobile service generate a outlookMobile link with guests 1`] = `"https://outlook.live.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party&to=hello%40example.com%2Canother%40example.com"`;
 
 exports[`outlookMobile service generate a outlookMobile link with time & timezone 1`] = `"https://outlook.live.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T13%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T11%3A00%3A00&subject=Birthday%20party"`;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,6 +92,9 @@ export const outlook = (calendarEvent: CalendarEvent): string => {
     location: event.location,
     allday: event.allDay || false,
   };
+  if (event.guests && event.guests.length) {
+    details.to = event.guests.join();
+  }
   return `https://outlook.live.com/calendar/0/action/compose?${stringify(details)}`;
 };
 
@@ -108,6 +111,9 @@ export const outlookMobile = (calendarEvent: CalendarEvent): string => {
     location: event.location,
     allday: event.allDay || false,
   };
+  if (event.guests && event.guests.length) {
+    details.to = event.guests.join();
+  }
   return `https://outlook.live.com/calendar/0/deeplink/compose?${stringify(details)}`;
 };
 
@@ -124,6 +130,9 @@ export const office365 = (calendarEvent: CalendarEvent): string => {
     location: event.location,
     allday: event.allDay || false,
   };
+  if (event.guests && event.guests.length) {
+    details.to = event.guests.join();
+  }
   return `https://outlook.office.com/calendar/0/action/compose?${stringify(details)}`;
 };
 
@@ -140,6 +149,9 @@ export const office365Mobile = (calendarEvent: CalendarEvent): string => {
     location: event.location,
     allday: event.allDay || false,
   };
+  if (event.guests && event.guests.length) {
+    details.to = event.guests.join();
+  }
   return `https://outlook.office.com/calendar/0/deeplink/compose?${stringify(details)}`;
 };
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -49,6 +49,7 @@ interface Outlook extends Record<string, string | boolean | number | undefined> 
   allday?: boolean;
   body?: string;
   location?: string;
+  to?: string;
 }
 
 interface Yahoo extends Record<string, string | boolean | number | undefined> {


### PR DESCRIPTION
I was looking at at bug report at my workplace as customers are complaining that guests are not added automatically and realised that this library currently doesn't support it.

Did some research and Github Copilot was suggesting that `to` query string key might work which turned out to be working when I tested on outlook.live and outlook.office. Tested with multiple guests too and it is also working on outlook.live. You could try this out `https://outlook.live.com/calendar/0/action/compose?subject=Test&rru=addevent&startdt=2025-06-12T14:00:00Z&enddt=2025-06-12T15:00:00Z&to=hello%40example.com%2Canother%40example.com` which has 2 guest emails.

I wasn't able to test on other outlook like mobile, 365 mobile though but thought that they all have the same path and query string structure so just added `to` to all of them as even if it is invalid, it won't break anything as that would be ignore. If you have a way to test it out that would be great