### PR TITLE
fix: ics link

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -308,7 +308,7 @@ export const ics = (calendarEvent: CalendarEvent): string => {
           `CN=${value.name}:MAILTO:${value.email}\r\n`
         )}`;
       } else {
-        calendarUrl += `${chunk.key}:${encodeURIComponent(`${chunk.value}\r\n`)}`;
+        calendarUrl += `${chunk.key}${encodeURIComponent(`:${chunk.value}\r\n`)}`;
       }
     }
   });


### PR DESCRIPTION
The colon needs to be encoded too,
I tested on Safari and couldn't open the generated link unless changing the encoding of the colon

Thanks!