### PR TITLE
:sparkles: Named timezones for ics and google

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ ics(event); // standard ICS file based on https://icalendar.org
 | `guests`           | Emails of other guests. This is currently only supported for `google`, `outlook`, `outlookMobile`, `office365`, `office365Mobile` and `msTeams`          | Array of emails (String)                                                                                                                  |
 | `url`              | Calendar document URL           | String                                                                                                                                    |
 | `uid`              | Unique identifier for the event | String                                                                                                                                    |
+| `tz`               | Named timezone                  | IANA timezone name (e.g., 'Europe/Amsterdam')                                                                                             |
 
 #### Notes
 
@@ -65,6 +66,7 @@ ics(event); // standard ICS file based on https://icalendar.org
 - If you don't pass the start and end time in UTC, Google will convert it to UTC but Outlook won't, so it's a good idea to use UTC when passing dates and times
 - There are some known issues in Office 365 because of which we can't generate a consistent link in all devices (#542)
 - The `uid` field is currently optional and will generate a random ID if not provided. In a future version, this field will be required to ensure proper event identification and deduplication.
+- The `tz` field is processed for all link types, but its specific named timezone information is only fully implemented and preserved in the generated links for `google` and `ics` services. Other services may convert the time to UTC or treat it as a floating local time.
 
 ## Compatibility
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,4 +3,5 @@ module.exports = {
   globalSetup: "./jest-global-setup.js",
   testEnvironment: "node",
   watchPathIgnorePatterns: ['node_modules'],
+  testPathIgnorePatterns: ['/node_modules/', '/dist/'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,10 +6,11 @@
   "packages": {
     "": {
       "name": "calendar-link",
-      "version": "2.10.0",
+      "version": "2.11.0",
       "license": "MIT",
       "dependencies": {
-        "dayjs": "^1.9.3"
+        "dayjs": "^1.9.3",
+        "timezones-ical-library": "^1.0.4"
       },
       "devDependencies": {
         "@koj/config": "1.2.11",
@@ -17,14 +18,14 @@
         "@semantic-release/git": "^9.0.0",
         "@semantic-release/github": "^7.1.1",
         "@semantic-release/npm": "^7.0.6",
-        "@types/jest": "^26.0.14",
-        "jest": "^26.6.0",
+        "@types/jest": "^26.0.24",
+        "jest": "^26.6.3",
         "microbundle": "^0.15.1",
         "npm-run-all": "^4.1.5",
         "semantic-release": "^17.2.1",
         "semantic-release-gitmoji": "^1.3.4",
-        "ts-jest": "^26.4.1",
-        "typescript": "^4.0.3"
+        "ts-jest": "^26.5.6",
+        "typescript": "^4.9.5"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -47,6 +48,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.3.tgz",
       "integrity": "sha512-0qXcZYKZp3/6N2jKYVxZv0aNCsxTSVCiK72DTiTYZAu7sjg73W0/aynWjMbiGd87EQL4WyA8reiJVh92AVla9g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/generator": "^7.12.1",
@@ -2106,6 +2108,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.2.1.tgz",
       "integrity": "sha512-XfFSDDwv6tclUenS0EmB6iA7u+4aOHBT1Lz4PtQNQQg3hBbNaR/+Uv5URU+egeIuuGAiMRiDyY92G4GBOWOqDA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^2.4.0",
         "@octokit/graphql": "^4.3.1",
@@ -2812,6 +2815,7 @@
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.12.tgz",
       "integrity": "sha512-wMTHiiTiBAAPebqaPiPDLFA4LYPKr6Ph0Xq/6rq1Ur3v66HXyG+clfR9CNETkD7MQS8ZHvpQOtA53DLws5WAEQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.1.0",
         "@babel/types": "^7.0.0",
@@ -2894,10 +2898,11 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "26.0.20",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.20.tgz",
-      "integrity": "sha512-9zi2Y+5USJRxd0FsahERhBwlcvFh6D2GLQnY2FH2BzK8J9s9omvNHIbvABwIluXa0fD8XVKMLTO0aOEuUfACAA==",
+      "version": "26.0.24",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.24.tgz",
+      "integrity": "sha512-E/X5Vib8BWqZNRlDxj9vYXhsDwPYbPINqKF9BsnSoon4RQ0D9moEuLD8txgyypFLH7J4+Lho9Nr/c8H0Fi+17w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "jest-diff": "^26.0.0",
         "pretty-format": "^26.0.0"
@@ -7806,6 +7811,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-26.6.3.tgz",
       "integrity": "sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/core": "^26.6.3",
         "import-local": "^3.0.2",
@@ -9214,22 +9220,6 @@
         "node": ">= 10.13.0"
       }
     },
-    "node_modules/jest/node_modules/@jest/types": {
-      "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
-      "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^15.0.0",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 10.14.2"
-      }
-    },
     "node_modules/jest/node_modules/jest-cli": {
       "version": "26.6.3",
       "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.6.3.tgz",
@@ -9252,23 +9242,6 @@
       },
       "bin": {
         "jest": "bin/jest.js"
-      },
-      "engines": {
-        "node": ">= 10.14.2"
-      }
-    },
-    "node_modules/jest/node_modules/jest-util": {
-      "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.2.tgz",
-      "integrity": "sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==",
-      "dev": true,
-      "dependencies": {
-        "@jest/types": "^26.6.2",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.4",
-        "is-ci": "^2.0.0",
-        "micromatch": "^4.0.2"
       },
       "engines": {
         "node": ">= 10.14.2"
@@ -15909,6 +15882,7 @@
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.4.tgz",
       "integrity": "sha512-kRFftRoExRVXZlwUuay9iC824qmXPcQQVzAjbCCgjpXnkdMCJYBu2gTwAaFBzv8ewND6O8xFb3aELmEkh9zTzg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "colorette": "^1.2.1",
         "nanoid": "^3.1.20",
@@ -19731,6 +19705,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.38.0.tgz",
       "integrity": "sha512-ay9zDiNitZK/LNE/EM2+v5CZ7drkB2xyDljvb1fQJCGnq43ZWRkhxN145oV8GmoW1YNi4sA/1Jdkr2LfawJoXw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -20308,6 +20283,7 @@
       "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-17.4.1.tgz",
       "integrity": "sha512-o/Rjk0HCBUWEYxN99Vq04Th+XtRQAxbC+FN+pBQ49wpqQ5NW/cfwhfw0qyxeTEhbchQ/1/KGMPWqD4/rRScAag==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^8.0.0",
         "@semantic-release/error": "^2.2.0",
@@ -20499,6 +20475,7 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.0.tgz",
       "integrity": "sha512-NqRSh2+LlN2NInpqTQnS614Y/3NkVMFFU6sJlRFEpxJ/LHuK/qJECH7/fXZjk4VZstPW/Pevjil/VtSONsLc7Q==",
       "dev": true,
+      "peer": true,
       "bin": {
         "marked": "bin/marked"
       },
@@ -21899,6 +21876,16 @@
         "readable-stream": "3"
       }
     },
+    "node_modules/timezones-ical-library": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/timezones-ical-library/-/timezones-ical-library-1.10.0.tgz",
+      "integrity": "sha512-aSwylC0FyyxMqMjkuaYz56HBhhooYabGT74CbTuY1uOeIcBXSQTXf+u/mTR0MWJFPQDe21REjex+4wt0OdFDpA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.17.0",
+        "npm": ">=9.6.7"
+      }
+    },
     "node_modules/timsort": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
@@ -22032,10 +22019,11 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "26.5.3",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.5.3.tgz",
-      "integrity": "sha512-nBiiFGNvtujdLryU7MiMQh1iPmnZ/QvOskBbD2kURiI1MwqvxlxNnaAB/z9TbslMqCsSbu5BXvSSQPc5tvHGeA==",
+      "version": "26.5.6",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.5.6.tgz",
+      "integrity": "sha512-rua+rCP8DxpA8b4DQD/6X2HQS8Zy/xzViVYfEs2OQu68tkCuKLV0Md8pmX55+W24uRIyAsf/BajRfxOs+R2MKA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bs-logger": "0.x",
         "buffer-from": "1.x",
@@ -22147,10 +22135,12 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -51,16 +51,17 @@
     "@semantic-release/git": "^9.0.0",
     "@semantic-release/github": "^7.1.1",
     "@semantic-release/npm": "^7.0.6",
-    "@types/jest": "^26.0.14",
-    "jest": "^26.6.0",
+    "@types/jest": "^26.0.24",
+    "jest": "^26.6.3",
     "microbundle": "^0.15.1",
     "npm-run-all": "^4.1.5",
     "semantic-release": "^17.2.1",
     "semantic-release-gitmoji": "^1.3.4",
-    "ts-jest": "^26.4.1",
-    "typescript": "^4.0.3"
+    "ts-jest": "^26.5.6",
+    "typescript": "^4.9.5"
   },
   "dependencies": {
-    "dayjs": "^1.9.3"
+    "dayjs": "^1.9.3",
+    "timezones-ical-library": "^1.0.4"
   }
 }

--- a/src/__snapshots__/index.spec.ts.snap
+++ b/src/__snapshots__/index.spec.ts.snap
@@ -2,6 +2,8 @@
 
 exports[`aol service generate a aol link 1`] = `"https://calendar.aol.com/?dur=false&et=20191229T020000Z&st=20191229T000000Z&title=Birthday%20party&v=60"`;
 
+exports[`aol service generate a aol link with a named timezone 1`] = `"https://calendar.aol.com/?dur=false&et=20991229T130000Z&st=20991229T110000Z&title=Birthday%20party&v=60"`;
+
 exports[`aol service generate a aol link with description 1`] = `"https://calendar.aol.com/?desc=Bring%20gifts%21&dur=false&et=20191229T020000Z&st=20191229T000000Z&title=Birthday%20party&v=60"`;
 
 exports[`aol service generate a aol link with guests 1`] = `"https://calendar.aol.com/?dur=false&et=20191229T020000Z&st=20191229T000000Z&title=Birthday%20party&v=60"`;
@@ -16,6 +18,8 @@ exports[`aol service generate an all day aol link 1`] = `"https://calendar.aol.c
 
 exports[`google service generate a google link 1`] = `"https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20191229T000000Z%2F20191229T020000Z&text=Birthday%20party"`;
 
+exports[`google service generate a google link with a named timezone 1`] = `"https://calendar.google.com/calendar/render?action=TEMPLATE&ctz=Europe%2FAmsterdam&dates=20991229T120000%2F20991229T140000&text=Birthday%20party"`;
+
 exports[`google service generate a google link with description 1`] = `"https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20191229T000000Z%2F20191229T020000Z&details=Bring%20gifts%21&text=Birthday%20party"`;
 
 exports[`google service generate a google link with guests 1`] = `"https://calendar.google.com/calendar/render?action=TEMPLATE&add=hello%40example.com%2Canother%40example.com&dates=20191229T000000Z%2F20191229T020000Z&text=Birthday%20party"`;
@@ -29,6 +33,8 @@ exports[`google service generate a recurring google link 1`] = `"https://calenda
 exports[`google service generate an all day google link 1`] = `"https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20191229%2F20191230&text=Birthday%20party"`;
 
 exports[`ics service generate a ics link 1`] = `"data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0D%0AVERSION:2.0%0D%0APRODID:-%2F%2FAnandChowdhary%2F%2Fcalendar-link%2F%2FEN%0D%0ABEGIN:VEVENT%0D%0ADTSTART:20191229T000000Z%0D%0ADTEND:20191229T020000Z%0D%0ADTSTAMP:20191228T120000Z%0D%0ASUMMARY:Birthday%20party%0D%0AUID:12345%0D%0AEND:VEVENT%0D%0AEND:VCALENDAR%0D%0A"`;
+
+exports[`ics service generate a ics link with a named timezone 1`] = `"data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0D%0AVERSION:2.0%0D%0APRODID:-%2F%2FAnandChowdhary%2F%2Fcalendar-link%2F%2FEN%0D%0ABEGIN%3AVTIMEZONE%0D%0ATZID%3AEurope%2FBrussels%0D%0AX-LIC-LOCATION%3AEurope%2FBrussels%0D%0ALAST-MODIFIED%3A20250523T094234Z%0D%0AX-LIC-LOCATION%3AEurope%2FBrussels%0D%0ABEGIN%3ADAYLIGHT%0D%0ATZNAME%3ACEST%0D%0ATZOFFSETFROM%3A%2B0100%0D%0ATZOFFSETTO%3A%2B0200%0D%0ADTSTART%3A19700329T020000%0D%0ARRULE%3AFREQ%3DYEARLY%3BBYMONTH%3D3%3BBYDAY%3D-1SU%0D%0AEND%3ADAYLIGHT%0D%0ABEGIN%3ASTANDARD%0D%0ATZNAME%3ACET%0D%0ATZOFFSETFROM%3A%2B0200%0D%0ATZOFFSETTO%3A%2B0100%0D%0ADTSTART%3A19701025T030000%0D%0ARRULE%3AFREQ%3DYEARLY%3BBYMONTH%3D10%3BBYDAY%3D-1SU%0D%0AEND%3ASTANDARD%0D%0AEND%3AVTIMEZONE%0D%0ABEGIN:VEVENT%0D%0ADTSTART;TZID=Europe/Brussels:20991229T120000%0D%0ADTEND;TZID=Europe/Brussels:20991229T140000%0D%0ADTSTAMP:20191228T120000Z%0D%0ASUMMARY:Birthday%20party%0D%0AUID:12345%0D%0AEND:VEVENT%0D%0AEND:VCALENDAR%0D%0A"`;
 
 exports[`ics service generate a ics link with description 1`] = `"data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0D%0AVERSION:2.0%0D%0APRODID:-%2F%2FAnandChowdhary%2F%2Fcalendar-link%2F%2FEN%0D%0ABEGIN:VEVENT%0D%0ADTSTART:20191229T000000Z%0D%0ADTEND:20191229T020000Z%0D%0ADTSTAMP:20191228T120000Z%0D%0ASUMMARY:Birthday%20party%0D%0ADESCRIPTION:Bring%20gifts!%0D%0AUID:12345%0D%0AEND:VEVENT%0D%0AEND:VCALENDAR%0D%0A"`;
 
@@ -46,6 +52,8 @@ exports[`ics service generate an all day ics link 1`] = `"data:text/calendar;cha
 
 exports[`msTeams service generate a msTeams link 1`] = `"https://teams.microsoft.com/l/meeting/new?endTime=2019-12-29T02%3A00%3A00.000Z&startTime=2019-12-29T00%3A00%3A00.000Z&subject=Birthday%20party"`;
 
+exports[`msTeams service generate a msTeams link with a named timezone 1`] = `"https://teams.microsoft.com/l/meeting/new?endTime=2099-12-29T13%3A00%3A00.000Z&startTime=2099-12-29T11%3A00%3A00.000Z&subject=Birthday%20party"`;
+
 exports[`msTeams service generate a msTeams link with description 1`] = `"https://teams.microsoft.com/l/meeting/new?content=Bring%20gifts%21&endTime=2019-12-29T02%3A00%3A00.000Z&startTime=2019-12-29T00%3A00%3A00.000Z&subject=Birthday%20party"`;
 
 exports[`msTeams service generate a msTeams link with guests 1`] = `"https://teams.microsoft.com/l/meeting/new?attendees=hello%40example.com%2Canother%40example.com&endTime=2019-12-29T02%3A00%3A00.000Z&startTime=2019-12-29T00%3A00%3A00.000Z&subject=Birthday%20party"`;
@@ -62,6 +70,8 @@ exports[`office365 service generate a multi day office365 link 1`] = `"https://o
 
 exports[`office365 service generate a office365 link 1`] = `"https://outlook.office.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
+exports[`office365 service generate a office365 link with a named timezone 1`] = `"https://outlook.office.com/calendar/0/action/compose?allday=false&enddt=2099-12-29T13%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2099-12-29T11%3A00%3A00&subject=Birthday%20party"`;
+
 exports[`office365 service generate a office365 link with description 1`] = `"https://outlook.office.com/calendar/0/action/compose?allday=false&body=Bring%20gifts%21&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
 exports[`office365 service generate a office365 link with guests 1`] = `"https://outlook.office.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party&to=hello%40example.com%2Canother%40example.com"`;
@@ -75,6 +85,8 @@ exports[`office365 service generate an all day office365 link 1`] = `"https://ou
 exports[`office365Mobile service generate a multi day office365Mobile link 1`] = `"https://outlook.office.com/calendar/0/deeplink/compose?allday=true&enddt=2020-01-12T00%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
 exports[`office365Mobile service generate a office365Mobile link 1`] = `"https://outlook.office.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
+
+exports[`office365Mobile service generate a office365Mobile link with a named timezone 1`] = `"https://outlook.office.com/calendar/0/deeplink/compose?allday=false&enddt=2099-12-29T13%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2099-12-29T11%3A00%3A00&subject=Birthday%20party"`;
 
 exports[`office365Mobile service generate a office365Mobile link with description 1`] = `"https://outlook.office.com/calendar/0/deeplink/compose?allday=false&body=Bring%20gifts%21&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
@@ -90,6 +102,8 @@ exports[`outlook service generate a multi day outlook link 1`] = `"https://outlo
 
 exports[`outlook service generate a outlook link 1`] = `"https://outlook.live.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
+exports[`outlook service generate a outlook link with a named timezone 1`] = `"https://outlook.live.com/calendar/0/action/compose?allday=false&enddt=2099-12-29T13%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2099-12-29T11%3A00%3A00&subject=Birthday%20party"`;
+
 exports[`outlook service generate a outlook link with description 1`] = `"https://outlook.live.com/calendar/0/action/compose?allday=false&body=Bring%20gifts%21&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
 exports[`outlook service generate a outlook link with guests 1`] = `"https://outlook.live.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party&to=hello%40example.com%2Canother%40example.com"`;
@@ -103,6 +117,8 @@ exports[`outlook service generate an all day outlook link 1`] = `"https://outloo
 exports[`outlookMobile service generate a multi day outlookMobile link 1`] = `"https://outlook.live.com/calendar/0/deeplink/compose?allday=true&enddt=2020-01-12T00%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
 exports[`outlookMobile service generate a outlookMobile link 1`] = `"https://outlook.live.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
+
+exports[`outlookMobile service generate a outlookMobile link with a named timezone 1`] = `"https://outlook.live.com/calendar/0/deeplink/compose?allday=false&enddt=2099-12-29T13%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2099-12-29T11%3A00%3A00&subject=Birthday%20party"`;
 
 exports[`outlookMobile service generate a outlookMobile link with description 1`] = `"https://outlook.live.com/calendar/0/deeplink/compose?allday=false&body=Bring%20gifts%21&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
@@ -119,6 +135,8 @@ exports[`yahoo service generate a multi day yahoo link 1`] = `"https://calendar.
 exports[`yahoo service generate a recurring yahoo link 1`] = `"https://calendar.yahoo.com/?dur=false&et=20191229T020000Z&st=20191229T000000Z&title=Birthday%20party&v=60"`;
 
 exports[`yahoo service generate a yahoo link 1`] = `"https://calendar.yahoo.com/?dur=false&et=20191229T020000Z&st=20191229T000000Z&title=Birthday%20party&v=60"`;
+
+exports[`yahoo service generate a yahoo link with a named timezone 1`] = `"https://calendar.yahoo.com/?dur=false&et=20991229T130000Z&st=20991229T110000Z&title=Birthday%20party&v=60"`;
 
 exports[`yahoo service generate a yahoo link with description 1`] = `"https://calendar.yahoo.com/?desc=Bring%20gifts%21&dur=false&et=20191229T020000Z&st=20191229T000000Z&title=Birthday%20party&v=60"`;
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -65,6 +65,17 @@ for (const service of [
       expect(link).toMatchSnapshot();
     });
 
+    test(`generate a ${service.name} link with a named timezone`, () => {
+      const event: CalendarEvent = {
+        title: "Birthday party",
+        start: "2099-12-29T12:00:00.000",
+        duration: [2, "hour"],
+        tz: "Europe/Amsterdam",
+      };
+      const link = service(event);
+      expect(link).toMatchSnapshot();
+    });
+
     test(`generate an all day ${service.name} link`, () => {
       const event: CalendarEvent = {
         title: "Birthday party",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
+import timezone from "dayjs/plugin/timezone";
 
 import {
   CalendarEvent,
@@ -12,8 +13,10 @@ import {
   Yahoo,
 } from "./interfaces";
 import { TimeFormats } from "./utils";
+import { tzlib_get_ical_block } from "timezones-ical-library";
 
 dayjs.extend(utc);
+dayjs.extend(timezone);
 
 function stringify(input: Record<string, any>): string {
   const params = new URLSearchParams();
@@ -36,34 +39,69 @@ function formatTimes(
   return { start: startTime.format(format), end: endTime.format(format) };
 }
 
-export const eventify = (event: CalendarEvent, toUtc: boolean = true): NormalizedCalendarEvent => {
-  const { start, end, duration, ...rest } = event;
-  const startTime = toUtc ? dayjs(start).utc() : dayjs(start);
-  const endTime = end
-    ? toUtc
-      ? dayjs(end).utc()
-      : dayjs(end)
-    : (() => {
-        if (event.allDay) {
-          return startTime.add(1, "day");
-        }
-        if (duration && duration.length == 2) {
-          const value = Number(duration[0]);
-          const unit = duration[1];
-          return startTime.add(value, unit);
-        }
-        return startTime;
-      })();
+export const eventify = ({
+  event,
+  isLocalFloatingTime = false,
+  toUtc = true,
+}: {
+  event: CalendarEvent;
+  isLocalFloatingTime?: boolean;
+  toUtc?: boolean;
+}): NormalizedCalendarEvent => {
+  const { start, end, duration, tz, allDay, ...rest } = event;
+
+  if (isLocalFloatingTime && toUtc) {
+    // `isLocalFloatingTime` and `toUtc` params are mutually exclusive
+    toUtc = false;
+  }
+
+  if (duration && allDay) {
+    throw new Error("`duration` and `allDay` params are mutually exclusive");
+  }
+
+  if (end && duration) {
+    throw new Error("Cannot specify `duration` with `end`");
+  }
+
+  let startTime = tz ? dayjs.tz(start, tz) : dayjs(start);
+  let endTime;
+
+  if (end) {
+    endTime = tz ? dayjs.tz(end, tz) : dayjs(end);
+  } else {
+    if (allDay) {
+      endTime = startTime.add(1, "day");
+    } else if (duration) {
+      const value = Number(duration[0]);
+      const unit = duration[1];
+      endTime = startTime.add(value, unit);
+    } else {
+      endTime = startTime.clone();
+    }
+  }
+
+  if (isLocalFloatingTime) {
+    startTime = startTime.local();
+    endTime = endTime.local();
+  }
+
+  if (toUtc) {
+    startTime = startTime.utc();
+    endTime = endTime.utc();
+  }
+
   return {
     ...rest,
     startTime: startTime,
     endTime: endTime,
+    tz: tz,
+    allDay,
   };
 };
 
 export const google = (calendarEvent: CalendarEvent): string => {
-  const event = eventify(calendarEvent);
-  const { start, end } = formatTimes(event, event.allDay ? "allDay" : "dateTimeUTC");
+  const event = eventify({ event: calendarEvent, toUtc: !calendarEvent.tz });
+  const { start, end } = formatTimes(event, event.allDay ? "allDay" : (event.tz ? "dateTimeTZ" : "dateTimeUTC"));
   const details: Google = {
     action: "TEMPLATE",
     text: event.title,
@@ -72,6 +110,7 @@ export const google = (calendarEvent: CalendarEvent): string => {
     trp: event.busy,
     dates: start + "/" + end,
     recur: event.rRule ? "RRULE:" + event.rRule : undefined,
+    ctz: event.tz || undefined,
   };
   if (event.guests && event.guests.length) {
     details.add = event.guests.join();
@@ -80,7 +119,7 @@ export const google = (calendarEvent: CalendarEvent): string => {
 };
 
 export const outlook = (calendarEvent: CalendarEvent): string => {
-  const event = eventify(calendarEvent, false);
+  const event = eventify({ event: calendarEvent, isLocalFloatingTime: true, toUtc: false });
   const { start, end } = formatTimes(event, "dateTimeLocal");
   const details: Outlook = {
     path: "/calendar/action/compose",
@@ -99,7 +138,7 @@ export const outlook = (calendarEvent: CalendarEvent): string => {
 };
 
 export const outlookMobile = (calendarEvent: CalendarEvent): string => {
-  const event = eventify(calendarEvent, false);
+  const event = eventify({ event: calendarEvent, isLocalFloatingTime: true, toUtc: false });
   const { start, end } = formatTimes(event, "dateTimeLocal");
   const details: Outlook = {
     path: "/calendar/action/compose",
@@ -118,7 +157,7 @@ export const outlookMobile = (calendarEvent: CalendarEvent): string => {
 };
 
 export const office365 = (calendarEvent: CalendarEvent): string => {
-  const event = eventify(calendarEvent, false);
+  const event = eventify({ event: calendarEvent, isLocalFloatingTime: true, toUtc: false });
   const { start, end } = formatTimes(event, "dateTimeLocal");
   const details: Outlook = {
     path: "/calendar/action/compose",
@@ -137,7 +176,7 @@ export const office365 = (calendarEvent: CalendarEvent): string => {
 };
 
 export const office365Mobile = (calendarEvent: CalendarEvent): string => {
-  const event = eventify(calendarEvent, false);
+  const event = eventify({ event: calendarEvent, isLocalFloatingTime: true, toUtc: false });
   const { start, end } = formatTimes(event, "dateTimeLocal");
   const details: Outlook = {
     path: "/calendar/action/compose",
@@ -156,7 +195,7 @@ export const office365Mobile = (calendarEvent: CalendarEvent): string => {
 };
 
 export const yahoo = (calendarEvent: CalendarEvent): string => {
-  const event = eventify(calendarEvent);
+  const event = eventify({ event: calendarEvent, toUtc: true });
   const { start, end } = formatTimes(event, event.allDay ? "allDay" : "dateTimeUTC");
   const details: Yahoo = {
     v: 60,
@@ -171,8 +210,8 @@ export const yahoo = (calendarEvent: CalendarEvent): string => {
 };
 
 export const aol = (calendarEvent: CalendarEvent): string => {
-    const event = eventify(calendarEvent);
-    const { start, end } = formatTimes(event, event.allDay ? "allDay" : "dateTimeUTC");
+  const event = eventify({ event: calendarEvent, toUtc: true });
+   const { start, end } = formatTimes(event, event.allDay ? "allDay" : "dateTimeUTC");
     const details: Aol = {
       v: 60,
       title: event.title,
@@ -187,7 +226,7 @@ export const aol = (calendarEvent: CalendarEvent): string => {
 
 // https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/build-and-test/deep-link-workflow?tabs=teamsjs-v2#configure-deep-link-manually-to-open-a-meeting-scheduling-dialog
 export const msTeams = (calendarEvent: CalendarEvent): string => {
-  const event = eventify(calendarEvent);
+  const event = eventify({ event: calendarEvent, toUtc: true });
   const details: MsTeams = {
     subject: event.title,
     content: event.description,
@@ -201,7 +240,7 @@ export const msTeams = (calendarEvent: CalendarEvent): string => {
 };
 
 export const ics = (calendarEvent: CalendarEvent): string => {
-  const event = eventify(calendarEvent);
+  const event = eventify({ event: calendarEvent, toUtc: false });
   const formattedDescription: string = (event.description || "")
     .replace(/,/gm, ",")
     .replace(/;/gm, ";")
@@ -216,8 +255,22 @@ export const ics = (calendarEvent: CalendarEvent): string => {
     .replace(/\n/gm, "\\n")
     .replace(/(\\n)[\s\t]+/gm, "\\n");
 
-  const { start, end } = formatTimes(event, event.allDay ? "allDay" : "dateTimeUTC");
+  const { start, end } = formatTimes(event,
+      event.allDay  ? "allDay"
+    : event.tz      ? "dateTimeTZ"
+    : "dateTimeUTC"
+  )
   const dateStamp = dayjs(new Date()).utc().format(TimeFormats["dateTimeUTC"]);
+
+  let vtimezoneBlock = '';
+  let dtStartKey = "DTSTART";
+  let dtEndKey = "DTEND";
+  if (event.tz) {
+    const [block, tzidLine] = tzlib_get_ical_block(event.tz);
+    vtimezoneBlock = block;
+    dtStartKey = `DTSTART;${tzidLine}`;
+    dtEndKey = `DTEND;${tzidLine}`;
+  }
   const calendarChunks = [
     {
       key: "BEGIN",
@@ -231,6 +284,12 @@ export const ics = (calendarEvent: CalendarEvent): string => {
       key: "PRODID",
       value: "-//AnandChowdhary//calendar-link//EN"
     },
+    ...(vtimezoneBlock ? [
+      {
+        key: "VTIMEZONE_BLOCK",
+        value: vtimezoneBlock,
+      }
+    ] : []),
     {
       key: "BEGIN",
       value: "VEVENT",
@@ -240,11 +299,11 @@ export const ics = (calendarEvent: CalendarEvent): string => {
       value: event.url,
     },
     {
-      key: "DTSTART",
+      key: dtStartKey,
       value: start,
     },
     {
-      key: "DTEND",
+      key: dtEndKey,
       value: end,
     },
     {
@@ -307,6 +366,8 @@ export const ics = (calendarEvent: CalendarEvent): string => {
         calendarUrl += `${chunk.key};${encodeURIComponent(
           `CN=${value.name}:MAILTO:${value.email}\r\n`
         )}`;
+      } else if (chunk.key === "VTIMEZONE_BLOCK") {
+        calendarUrl += `${encodeURIComponent(`${chunk.value}\r\n`)}`; // VTIMEZONE block is already formatted
       } else {
         calendarUrl += `${chunk.key}:${encodeURIComponent(`${chunk.value}\r\n`)}`;
       }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -15,6 +15,7 @@ interface CalendarEvent {
   url?: string;
   status?: 'CONFIRMED' | 'TENTATIVE' | 'CANCELLED';
   uid?: string;
+  tz?: string;
 }
 
 interface CalendarEventOrganizer {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 export const TimeFormats = {
   dateTimeLocal: "YYYY-MM-DD[T]HH:mm:ss",
   dateTimeUTC: "YYYYMMDD[T]HHmmss[Z]",
+  dateTimeTZ: "YYYYMMDD[T]HHmmss",
   allDay: "YYYYMMDD",
 };


### PR DESCRIPTION
* New `tz` event field supports named timezones, e.g. "US/Pacific"

* Refactor eventify() to use named params and read easier

* Tests for `tz` field

* Update readme