### PR TITLE
fix: all day events should not have timezone off-by-one error

### DIFF
--- a/jest-global-setup.js
+++ b/jest-global-setup.js
@@ -1,3 +1,4 @@
 module.exports = async () => {
-  process.env.TZ = "UTC";
+  // do NOT use UTC here, so that we can properly test toUtc logic
+  process.env.TZ = "Europe/Copenhagen";
 };

--- a/src/__snapshots__/index.spec.ts.snap
+++ b/src/__snapshots__/index.spec.ts.snap
@@ -1,62 +1,62 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`aol service generate a aol link 1`] = `"https://calendar.aol.com/?dur=false&et=20191229T020000Z&st=20191229T000000Z&title=Birthday%20party&v=60"`;
+exports[`aol service generate a aol link 1`] = `"https://calendar.aol.com/?dur=false&et=20191229T010000Z&st=20191228T230000Z&title=Birthday%20party&v=60"`;
 
-exports[`aol service generate a aol link with description 1`] = `"https://calendar.aol.com/?desc=Bring%20gifts%21&dur=false&et=20191229T020000Z&st=20191229T000000Z&title=Birthday%20party&v=60"`;
+exports[`aol service generate a aol link with description 1`] = `"https://calendar.aol.com/?desc=Bring%20gifts%21&dur=false&et=20191229T010000Z&st=20191228T230000Z&title=Birthday%20party&v=60"`;
 
-exports[`aol service generate a aol link with guests 1`] = `"https://calendar.aol.com/?dur=false&et=20191229T020000Z&st=20191229T000000Z&title=Birthday%20party&v=60"`;
+exports[`aol service generate a aol link with guests 1`] = `"https://calendar.aol.com/?dur=false&et=20191229T010000Z&st=20191228T230000Z&title=Birthday%20party&v=60"`;
 
 exports[`aol service generate a aol link with time & timezone 1`] = `"https://calendar.aol.com/?dur=false&et=20191229T130000Z&st=20191229T110000Z&title=Birthday%20party&v=60"`;
 
 exports[`aol service generate a multi day aol link 1`] = `"https://calendar.aol.com/?dur=allday&et=20200112&st=20191229&title=Birthday%20party&v=60"`;
 
-exports[`aol service generate a recurring aol link 1`] = `"https://calendar.aol.com/?dur=false&et=20191229T020000Z&st=20191229T000000Z&title=Birthday%20party&v=60"`;
+exports[`aol service generate a recurring aol link 1`] = `"https://calendar.aol.com/?dur=false&et=20191229T010000Z&st=20191228T230000Z&title=Birthday%20party&v=60"`;
 
 exports[`aol service generate an all day aol link 1`] = `"https://calendar.aol.com/?dur=allday&et=20191230&st=20191229&title=Birthday%20party&v=60"`;
 
-exports[`google service generate a google link 1`] = `"https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20191229T000000Z%2F20191229T020000Z&text=Birthday%20party"`;
+exports[`google service generate a google link 1`] = `"https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20191228T230000Z%2F20191229T010000Z&text=Birthday%20party"`;
 
-exports[`google service generate a google link with description 1`] = `"https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20191229T000000Z%2F20191229T020000Z&details=Bring%20gifts%21&text=Birthday%20party"`;
+exports[`google service generate a google link with description 1`] = `"https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20191228T230000Z%2F20191229T010000Z&details=Bring%20gifts%21&text=Birthday%20party"`;
 
-exports[`google service generate a google link with guests 1`] = `"https://calendar.google.com/calendar/render?action=TEMPLATE&add=hello%40example.com%2Canother%40example.com&dates=20191229T000000Z%2F20191229T020000Z&text=Birthday%20party"`;
+exports[`google service generate a google link with guests 1`] = `"https://calendar.google.com/calendar/render?action=TEMPLATE&add=hello%40example.com%2Canother%40example.com&dates=20191228T230000Z%2F20191229T010000Z&text=Birthday%20party"`;
 
 exports[`google service generate a google link with time & timezone 1`] = `"https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20191229T110000Z%2F20191229T130000Z&text=Birthday%20party"`;
 
 exports[`google service generate a multi day google link 1`] = `"https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20191229%2F20200112&text=Birthday%20party"`;
 
-exports[`google service generate a recurring google link 1`] = `"https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20191229T000000Z%2F20191229T020000Z&recur=RRULE%3AFREQ%3DYEARLY%3BINTERVAL%3D1&text=Birthday%20party"`;
+exports[`google service generate a recurring google link 1`] = `"https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20191228T230000Z%2F20191229T010000Z&recur=RRULE%3AFREQ%3DYEARLY%3BINTERVAL%3D1&text=Birthday%20party"`;
 
 exports[`google service generate an all day google link 1`] = `"https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20191229%2F20191230&text=Birthday%20party"`;
 
-exports[`ics service generate a ics link 1`] = `"data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0D%0AVERSION:2.0%0D%0APRODID:-%2F%2FAnandChowdhary%2F%2Fcalendar-link%2F%2FEN%0D%0ABEGIN:VEVENT%0D%0ADTSTART:20191229T000000Z%0D%0ADTEND:20191229T020000Z%0D%0ADTSTAMP:20191228T120000Z%0D%0ASUMMARY:Birthday%20party%0D%0AUID:12345%0D%0AEND:VEVENT%0D%0AEND:VCALENDAR%0D%0A"`;
+exports[`ics service generate a ics link 1`] = `"data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0D%0AVERSION:2.0%0D%0APRODID:-%2F%2FAnandChowdhary%2F%2Fcalendar-link%2F%2FEN%0D%0ABEGIN:VEVENT%0D%0ADTSTART:20191228T230000Z%0D%0ADTEND:20191229T010000Z%0D%0ADTSTAMP:20191228T120000Z%0D%0ASUMMARY:Birthday%20party%0D%0AUID:12345%0D%0AEND:VEVENT%0D%0AEND:VCALENDAR%0D%0A"`;
 
-exports[`ics service generate a ics link with description 1`] = `"data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0D%0AVERSION:2.0%0D%0APRODID:-%2F%2FAnandChowdhary%2F%2Fcalendar-link%2F%2FEN%0D%0ABEGIN:VEVENT%0D%0ADTSTART:20191229T000000Z%0D%0ADTEND:20191229T020000Z%0D%0ADTSTAMP:20191228T120000Z%0D%0ASUMMARY:Birthday%20party%0D%0ADESCRIPTION:Bring%20gifts!%0D%0AUID:12345%0D%0AEND:VEVENT%0D%0AEND:VCALENDAR%0D%0A"`;
+exports[`ics service generate a ics link with description 1`] = `"data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0D%0AVERSION:2.0%0D%0APRODID:-%2F%2FAnandChowdhary%2F%2Fcalendar-link%2F%2FEN%0D%0ABEGIN:VEVENT%0D%0ADTSTART:20191228T230000Z%0D%0ADTEND:20191229T010000Z%0D%0ADTSTAMP:20191228T120000Z%0D%0ASUMMARY:Birthday%20party%0D%0ADESCRIPTION:Bring%20gifts!%0D%0AUID:12345%0D%0AEND:VEVENT%0D%0AEND:VCALENDAR%0D%0A"`;
 
-exports[`ics service generate a ics link with guests 1`] = `"data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0D%0AVERSION:2.0%0D%0APRODID:-%2F%2FAnandChowdhary%2F%2Fcalendar-link%2F%2FEN%0D%0ABEGIN:VEVENT%0D%0ADTSTART:20191229T000000Z%0D%0ADTEND:20191229T020000Z%0D%0ADTSTAMP:20191228T120000Z%0D%0ASUMMARY:Birthday%20party%0D%0AUID:12345%0D%0AEND:VEVENT%0D%0AEND:VCALENDAR%0D%0A"`;
+exports[`ics service generate a ics link with guests 1`] = `"data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0D%0AVERSION:2.0%0D%0APRODID:-%2F%2FAnandChowdhary%2F%2Fcalendar-link%2F%2FEN%0D%0ABEGIN:VEVENT%0D%0ADTSTART:20191228T230000Z%0D%0ADTEND:20191229T010000Z%0D%0ADTSTAMP:20191228T120000Z%0D%0ASUMMARY:Birthday%20party%0D%0AUID:12345%0D%0AEND:VEVENT%0D%0AEND:VCALENDAR%0D%0A"`;
 
 exports[`ics service generate a ics link with time & timezone 1`] = `"data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0D%0AVERSION:2.0%0D%0APRODID:-%2F%2FAnandChowdhary%2F%2Fcalendar-link%2F%2FEN%0D%0ABEGIN:VEVENT%0D%0ADTSTART:20191229T110000Z%0D%0ADTEND:20191229T130000Z%0D%0ADTSTAMP:20191228T120000Z%0D%0ASUMMARY:Birthday%20party%0D%0AUID:12345%0D%0AEND:VEVENT%0D%0AEND:VCALENDAR%0D%0A"`;
 
-exports[`ics service generate a ics link with uid 1`] = `"data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0D%0AVERSION:2.0%0D%0APRODID:-%2F%2FAnandChowdhary%2F%2Fcalendar-link%2F%2FEN%0D%0ABEGIN:VEVENT%0D%0ADTSTART:20191229T000000Z%0D%0ADTEND:20191229T020000Z%0D%0ADTSTAMP:20191228T120000Z%0D%0ASUMMARY:Birthday%20party%0D%0AUID:abc_123%0D%0AEND:VEVENT%0D%0AEND:VCALENDAR%0D%0A"`;
+exports[`ics service generate a ics link with uid 1`] = `"data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0D%0AVERSION:2.0%0D%0APRODID:-%2F%2FAnandChowdhary%2F%2Fcalendar-link%2F%2FEN%0D%0ABEGIN:VEVENT%0D%0ADTSTART:20191228T230000Z%0D%0ADTEND:20191229T010000Z%0D%0ADTSTAMP:20191228T120000Z%0D%0ASUMMARY:Birthday%20party%0D%0AUID:abc_123%0D%0AEND:VEVENT%0D%0AEND:VCALENDAR%0D%0A"`;
 
 exports[`ics service generate a multi day ics link 1`] = `"data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0D%0AVERSION:2.0%0D%0APRODID:-%2F%2FAnandChowdhary%2F%2Fcalendar-link%2F%2FEN%0D%0ABEGIN:VEVENT%0D%0ADTSTART:20191229%0D%0ADTEND:20200112%0D%0ADTSTAMP:20191228T120000Z%0D%0AX-MICROSOFT-CDO-ALLDAYEVENT:TRUE%0D%0AX-MICROSOFT-MSNCALENDAR-ALLDAYEVENT:TRUE%0D%0ASUMMARY:Birthday%20party%0D%0AUID:12345%0D%0AEND:VEVENT%0D%0AEND:VCALENDAR%0D%0A"`;
 
-exports[`ics service generate a recurring ics link 1`] = `"data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0D%0AVERSION:2.0%0D%0APRODID:-%2F%2FAnandChowdhary%2F%2Fcalendar-link%2F%2FEN%0D%0ABEGIN:VEVENT%0D%0ADTSTART:20191229T000000Z%0D%0ADTEND:20191229T020000Z%0D%0ADTSTAMP:20191228T120000Z%0D%0ARRULE:FREQ%3DYEARLY%3BINTERVAL%3D1%0D%0ASUMMARY:Birthday%20party%0D%0AUID:12345%0D%0AEND:VEVENT%0D%0AEND:VCALENDAR%0D%0A"`;
+exports[`ics service generate a recurring ics link 1`] = `"data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0D%0AVERSION:2.0%0D%0APRODID:-%2F%2FAnandChowdhary%2F%2Fcalendar-link%2F%2FEN%0D%0ABEGIN:VEVENT%0D%0ADTSTART:20191228T230000Z%0D%0ADTEND:20191229T010000Z%0D%0ADTSTAMP:20191228T120000Z%0D%0ARRULE:FREQ%3DYEARLY%3BINTERVAL%3D1%0D%0ASUMMARY:Birthday%20party%0D%0AUID:12345%0D%0AEND:VEVENT%0D%0AEND:VCALENDAR%0D%0A"`;
 
 exports[`ics service generate an all day ics link 1`] = `"data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0D%0AVERSION:2.0%0D%0APRODID:-%2F%2FAnandChowdhary%2F%2Fcalendar-link%2F%2FEN%0D%0ABEGIN:VEVENT%0D%0ADTSTART:20191229%0D%0ADTEND:20191230%0D%0ADTSTAMP:20191228T120000Z%0D%0AX-MICROSOFT-CDO-ALLDAYEVENT:TRUE%0D%0AX-MICROSOFT-MSNCALENDAR-ALLDAYEVENT:TRUE%0D%0ASUMMARY:Birthday%20party%0D%0ASTATUS:CONFIRMED%0D%0AUID:12345%0D%0AEND:VEVENT%0D%0AEND:VCALENDAR%0D%0A"`;
 
-exports[`msTeams service generate a msTeams link 1`] = `"https://teams.microsoft.com/l/meeting/new?endTime=2019-12-29T02%3A00%3A00.000Z&startTime=2019-12-29T00%3A00%3A00.000Z&subject=Birthday%20party"`;
+exports[`msTeams service generate a msTeams link 1`] = `"https://teams.microsoft.com/l/meeting/new?endTime=2019-12-29T01%3A00%3A00.000Z&startTime=2019-12-28T23%3A00%3A00.000Z&subject=Birthday%20party"`;
 
-exports[`msTeams service generate a msTeams link with description 1`] = `"https://teams.microsoft.com/l/meeting/new?content=Bring%20gifts%21&endTime=2019-12-29T02%3A00%3A00.000Z&startTime=2019-12-29T00%3A00%3A00.000Z&subject=Birthday%20party"`;
+exports[`msTeams service generate a msTeams link with description 1`] = `"https://teams.microsoft.com/l/meeting/new?content=Bring%20gifts%21&endTime=2019-12-29T01%3A00%3A00.000Z&startTime=2019-12-28T23%3A00%3A00.000Z&subject=Birthday%20party"`;
 
-exports[`msTeams service generate a msTeams link with guests 1`] = `"https://teams.microsoft.com/l/meeting/new?attendees=hello%40example.com%2Canother%40example.com&endTime=2019-12-29T02%3A00%3A00.000Z&startTime=2019-12-29T00%3A00%3A00.000Z&subject=Birthday%20party"`;
+exports[`msTeams service generate a msTeams link with guests 1`] = `"https://teams.microsoft.com/l/meeting/new?attendees=hello%40example.com%2Canother%40example.com&endTime=2019-12-29T01%3A00%3A00.000Z&startTime=2019-12-28T23%3A00%3A00.000Z&subject=Birthday%20party"`;
 
 exports[`msTeams service generate a msTeams link with time & timezone 1`] = `"https://teams.microsoft.com/l/meeting/new?endTime=2019-12-29T13%3A00%3A00.000Z&startTime=2019-12-29T11%3A00%3A00.000Z&subject=Birthday%20party"`;
 
-exports[`msTeams service generate a multi day msTeams link 1`] = `"https://teams.microsoft.com/l/meeting/new?endTime=2020-01-12T00%3A00%3A00.000Z&startTime=2019-12-29T00%3A00%3A00.000Z&subject=Birthday%20party"`;
+exports[`msTeams service generate a multi day msTeams link 1`] = `"https://teams.microsoft.com/l/meeting/new?endTime=2020-01-11T23%3A00%3A00.000Z&startTime=2019-12-28T23%3A00%3A00.000Z&subject=Birthday%20party"`;
 
-exports[`msTeams service generate a recurring msTeams link 1`] = `"https://teams.microsoft.com/l/meeting/new?endTime=2019-12-29T02%3A00%3A00.000Z&startTime=2019-12-29T00%3A00%3A00.000Z&subject=Birthday%20party"`;
+exports[`msTeams service generate a recurring msTeams link 1`] = `"https://teams.microsoft.com/l/meeting/new?endTime=2019-12-29T01%3A00%3A00.000Z&startTime=2019-12-28T23%3A00%3A00.000Z&subject=Birthday%20party"`;
 
-exports[`msTeams service generate an all day msTeams link 1`] = `"https://teams.microsoft.com/l/meeting/new?endTime=2019-12-30T00%3A00%3A00.000Z&startTime=2019-12-29T00%3A00%3A00.000Z&subject=Birthday%20party"`;
+exports[`msTeams service generate an all day msTeams link 1`] = `"https://teams.microsoft.com/l/meeting/new?endTime=2019-12-29T23%3A00%3A00.000Z&startTime=2019-12-28T23%3A00%3A00.000Z&subject=Birthday%20party"`;
 
 exports[`office365 service generate a multi day office365 link 1`] = `"https://outlook.office.com/calendar/0/action/compose?allday=true&enddt=2020-01-12T00%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
@@ -66,7 +66,7 @@ exports[`office365 service generate a office365 link with description 1`] = `"ht
 
 exports[`office365 service generate a office365 link with guests 1`] = `"https://outlook.office.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party&to=hello%40example.com%2Canother%40example.com"`;
 
-exports[`office365 service generate a office365 link with time & timezone 1`] = `"https://outlook.office.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T13%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T11%3A00%3A00&subject=Birthday%20party"`;
+exports[`office365 service generate a office365 link with time & timezone 1`] = `"https://outlook.office.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T14%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T12%3A00%3A00&subject=Birthday%20party"`;
 
 exports[`office365 service generate a recurring office365 link 1`] = `"https://outlook.office.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
@@ -80,7 +80,7 @@ exports[`office365Mobile service generate a office365Mobile link with descriptio
 
 exports[`office365Mobile service generate a office365Mobile link with guests 1`] = `"https://outlook.office.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party&to=hello%40example.com%2Canother%40example.com"`;
 
-exports[`office365Mobile service generate a office365Mobile link with time & timezone 1`] = `"https://outlook.office.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T13%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T11%3A00%3A00&subject=Birthday%20party"`;
+exports[`office365Mobile service generate a office365Mobile link with time & timezone 1`] = `"https://outlook.office.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T14%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T12%3A00%3A00&subject=Birthday%20party"`;
 
 exports[`office365Mobile service generate a recurring office365Mobile link 1`] = `"https://outlook.office.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
@@ -94,7 +94,7 @@ exports[`outlook service generate a outlook link with description 1`] = `"https:
 
 exports[`outlook service generate a outlook link with guests 1`] = `"https://outlook.live.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party&to=hello%40example.com%2Canother%40example.com"`;
 
-exports[`outlook service generate a outlook link with time & timezone 1`] = `"https://outlook.live.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T13%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T11%3A00%3A00&subject=Birthday%20party"`;
+exports[`outlook service generate a outlook link with time & timezone 1`] = `"https://outlook.live.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T14%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T12%3A00%3A00&subject=Birthday%20party"`;
 
 exports[`outlook service generate a recurring outlook link 1`] = `"https://outlook.live.com/calendar/0/action/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
@@ -108,7 +108,7 @@ exports[`outlookMobile service generate a outlookMobile link with description 1`
 
 exports[`outlookMobile service generate a outlookMobile link with guests 1`] = `"https://outlook.live.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party&to=hello%40example.com%2Canother%40example.com"`;
 
-exports[`outlookMobile service generate a outlookMobile link with time & timezone 1`] = `"https://outlook.live.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T13%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T11%3A00%3A00&subject=Birthday%20party"`;
+exports[`outlookMobile service generate a outlookMobile link with time & timezone 1`] = `"https://outlook.live.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T14%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T12%3A00%3A00&subject=Birthday%20party"`;
 
 exports[`outlookMobile service generate a recurring outlookMobile link 1`] = `"https://outlook.live.com/calendar/0/deeplink/compose?allday=false&enddt=2019-12-29T02%3A00%3A00&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-12-29T00%3A00%3A00&subject=Birthday%20party"`;
 
@@ -116,13 +116,13 @@ exports[`outlookMobile service generate an all day outlookMobile link 1`] = `"ht
 
 exports[`yahoo service generate a multi day yahoo link 1`] = `"https://calendar.yahoo.com/?dur=allday&et=20200112&st=20191229&title=Birthday%20party&v=60"`;
 
-exports[`yahoo service generate a recurring yahoo link 1`] = `"https://calendar.yahoo.com/?dur=false&et=20191229T020000Z&st=20191229T000000Z&title=Birthday%20party&v=60"`;
+exports[`yahoo service generate a recurring yahoo link 1`] = `"https://calendar.yahoo.com/?dur=false&et=20191229T010000Z&st=20191228T230000Z&title=Birthday%20party&v=60"`;
 
-exports[`yahoo service generate a yahoo link 1`] = `"https://calendar.yahoo.com/?dur=false&et=20191229T020000Z&st=20191229T000000Z&title=Birthday%20party&v=60"`;
+exports[`yahoo service generate a yahoo link 1`] = `"https://calendar.yahoo.com/?dur=false&et=20191229T010000Z&st=20191228T230000Z&title=Birthday%20party&v=60"`;
 
-exports[`yahoo service generate a yahoo link with description 1`] = `"https://calendar.yahoo.com/?desc=Bring%20gifts%21&dur=false&et=20191229T020000Z&st=20191229T000000Z&title=Birthday%20party&v=60"`;
+exports[`yahoo service generate a yahoo link with description 1`] = `"https://calendar.yahoo.com/?desc=Bring%20gifts%21&dur=false&et=20191229T010000Z&st=20191228T230000Z&title=Birthday%20party&v=60"`;
 
-exports[`yahoo service generate a yahoo link with guests 1`] = `"https://calendar.yahoo.com/?dur=false&et=20191229T020000Z&st=20191229T000000Z&title=Birthday%20party&v=60"`;
+exports[`yahoo service generate a yahoo link with guests 1`] = `"https://calendar.yahoo.com/?dur=false&et=20191229T010000Z&st=20191228T230000Z&title=Birthday%20party&v=60"`;
 
 exports[`yahoo service generate a yahoo link with time & timezone 1`] = `"https://calendar.yahoo.com/?dur=false&et=20191229T130000Z&st=20191229T110000Z&title=Birthday%20party&v=60"`;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,9 +38,9 @@ function formatTimes(
 
 export const eventify = (event: CalendarEvent, toUtc: boolean = true): NormalizedCalendarEvent => {
   const { start, end, duration, ...rest } = event;
-  const startTime = toUtc ? dayjs(start).utc() : dayjs(start);
+  const startTime = toUtc && !event.allDay ? dayjs(start).utc() : dayjs(start);
   const endTime = end
-    ? toUtc
+    ? toUtc && !event.allDay
       ? dayjs(end).utc()
       : dayjs(end)
     : (() => {


### PR DESCRIPTION
- fixes #678 
- problem was that `.utc()` should not be used for all day events - that will shift the date from local time to UTC time, which could move it to the wrong day
- fix is only testable by changing runtime timezone of jest
