### PR TITLE
:bug: Preserve all-day date-only events across timezones

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -11,6 +11,15 @@ import {
 } from "./index";
 import { CalendarEvent } from "./interfaces";
 
+describe("all-day events", () => {
+  test("ics date-only events are timezone-stable", () => {
+    const link = ics({ title: "Dec 29", start: "2025-12-29", allDay: true });
+
+    expect(decodeURIComponent(link)).toContain("DTSTART:20251229");
+    expect(decodeURIComponent(link)).toContain("DTEND:20251230");
+  });
+});
+
 for (const service of [
   aol,
   google,

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,13 +36,16 @@ function formatTimes(
   return { start: startTime.format(format), end: endTime.format(format) };
 }
 
+const parseDate = (date: CalendarEvent["start"], allDay?: boolean, toUtc: boolean = true) => {
+  if (allDay) return dayjs.utc(date);
+  return toUtc ? dayjs(date).utc() : dayjs(date);
+};
+
 export const eventify = (event: CalendarEvent, toUtc: boolean = true): NormalizedCalendarEvent => {
   const { start, end, duration, ...rest } = event;
-  const startTime = toUtc ? dayjs(start).utc() : dayjs(start);
+  const startTime = parseDate(start, event.allDay, toUtc);
   const endTime = end
-    ? toUtc
-      ? dayjs(end).utc()
-      : dayjs(end)
+    ? parseDate(end, event.allDay, toUtc)
     : (() => {
         if (event.allDay) {
           return startTime.add(1, "day");


### PR DESCRIPTION
## Summary
- Fixes all-day date-only parsing so `ics()` preserves the intended calendar date regardless of runtime timezone
- Adds a regression test for the Europe/Copenhagen off-by-one case from the issue

Fixes #678

## Test plan
- `TZ=Europe/Copenhagen npx jest src/index.spec.ts -t 'ics date-only events are timezone-stable' --runInBand --no-cache`
- `TZ=Europe/Copenhagen npm test -- --runInBand --no-cache`
- `npm run build`
