### PR TITLE
:construction_worker: Use active GitHub-hosted runner for PR tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   release:
     name: Build and test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- Updates the PR-only Test CI workflow from retired `ubuntu-18.04` to `ubuntu-latest`
- Unblocks the queued Build and test check on maintenance branches

## Test Plan
- `npm test -- --runInBand`
- `npm run build`

Follow-up to #694 post-merge CI verification.